### PR TITLE
Report the protection a transaction actually has

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -784,10 +784,10 @@ public class AppServices {
     /**
      * The activation height per network, or null where the fork is not scheduled.
      *
-     * A height is the part of this decision a server cannot influence, which is why it comes first. On
-     * mainnet the fork has no schedule, so nothing a server says can make a wallet opt in; without that
-     * floor a hostile or intercepted server could serve a forged v2 header today and every transaction
-     * the wallet produced would be rejected by the network as an undefined hash type.
+     * A height is the part of this decision a server cannot influence, which is why it comes first. Mainnet and
+     * testnet4 both ship one, so a server announcing a forged v2 header cannot bring an opt-in forward: the height
+     * has to be reached as well. The height itself is cross checked against the connected node where it reports one,
+     * and a disagreement declines rather than following either side.
      *
      * Regtest chooses its own height through -testactivationheight, so there is nothing to hardcode and
      * the chain is the only available answer there.
@@ -989,8 +989,9 @@ public class AppServices {
     /**
      * As canSignUnified, keeping the reason. A software seed signs from a key the wallet holds, so its support is
      * not in question; a device is taken at its owner's word, since nothing it sends says which firmware it runs.
-     * SW_WATCH is neither: it produces no signature at all, so the wallet is in no position to opt in whatever it
-     * has been marked as.
+     * A watch only keystore is in the same position as a device: the wallet is choosing what to declare in a PSBT it
+     * hands out, the signer behind it is the one that answers, and only the owner can say what that signer does. See
+     * canBeMarked, which admits both.
      *
      * A PSBT carries one hash type for every signer, so opting in needs enough of them marked to meet the threshold.
      */
@@ -1160,7 +1161,7 @@ public class AppServices {
         return wallet.getKeystores().stream()
                 .filter(keystore -> keystore.getKeyDerivation() != null
                         && fingerprint.equalsIgnoreCase(keystore.getKeyDerivation().getMasterFingerprint()))
-                .anyMatch(keystore -> keystore.getSource().isHardware() && !keystore.isUnifiedSigHashSupported());
+                .anyMatch(keystore -> canBeMarked(keystore) && !keystore.isUnifiedSigHashSupported());
     }
 
     /**
@@ -1199,7 +1200,7 @@ public class AppServices {
      * and getKey returns a private key for it, so it signs in process exactly as a software seed does. It is
      * grouped with SW_SEED on the sign button upstream for the same reason.
      */
-    static boolean signsInProcess(Keystore keystore) {
+    public static boolean signsInProcess(Keystore keystore) {
         KeystoreSource source = keystore.getSource();
         return source == KeystoreSource.SW_SEED || source == KeystoreSource.SW_PAYMENT_CODE;
     }
@@ -1250,11 +1251,51 @@ public class AppServices {
             return keystores;
         }
 
-        //Both opted in, and either may qualify it. The chain's caveat is about whether the schedule this signed
-        //under is the right one, which decides whether the protection holds at all. The keystores' is about who
-        //can sign what was built. The first is worth more, so it wins where both apply, and returning the chain's
-        //answer is also what stops an uncorroborated opt-in being reported as a confirmed one.
-        return chainDecision == UnifiedSigHashDecision.OPTED_IN ? keystores : chainDecision;
+        //Both opted in, and either may qualify it. The headline has to state the weaker of the two claims, and a
+        //conditional opt-in is the weaker: it can end in no protection at all if a quorum of signers that cannot opt
+        //in signs, where an uncorroborated one is protection whose schedule merely went unconfirmed. Only one of the
+        //two can be the headline, so the other is still reported through combinedCaveats rather than dropped.
+        return keystores == UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS ? keystores : chainDecision;
+    }
+
+    /**
+     * Every caveat that applies, in the order they qualify the opt-in.
+     *
+     * The decision above can only carry one, and on an Electrum connection both apply at once: no server reports an
+     * activation height, so an opt-in there is always uncorroborated, and a partially marked multisig adds its own.
+     * Reporting only the headline's caveat left the common configuration never told that a quorum of signers which
+     * cannot opt in would produce no protection.
+     */
+    public static List<String> getUnifiedSigHashCaveats(Wallet wallet) {
+        ChainTip tip = announcedTip;
+        UnifiedSigHashDecision chain = chainDecision(Network.get(), tip == null ? null : tip.height(), tip == null ? null : tip.header());
+        if(!chain.isOptedIn()) {
+            return List.of();
+        }
+
+        UnifiedSigHashDecision keystores = keystoreDecision(wallet);
+        if(!keystores.isOptedIn()) {
+            return List.of();
+        }
+
+        List<String> caveats = new ArrayList<>();
+        if(keystores.getCaveat() != null) {
+            caveats.add(keystores.getCaveat() + markedSignerSuffix(wallet));
+        }
+        if(chain.getCaveat() != null) {
+            caveats.add(chain.getCaveat());
+        }
+
+        return caveats;
+    }
+
+    /**
+     * The signers that can produce the opt-in, appended to the quorum caveat that would otherwise leave the reader to
+     * go and find out which ones those are. Belongs to that caveat alone: after any other it names nothing.
+     */
+    private static String markedSignerSuffix(Wallet wallet) {
+        String names = markedSignerNames(wallet);
+        return names == null ? "" : " Those are: " + names + ".";
     }
 
     /**

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -1307,8 +1307,9 @@ public class AppServices {
     /**
      * Creates the PSBT for a transaction being sent, opting in to the unified signature hash where the
      * chain has it and this wallet holds the keys. Every wallet send path goes through here so the
-     * decision is made in one place; the private key sweep builds its own PSBT from a key that is not in
-     * a wallet, and keeps signing the way it does today.
+     * decision is made in one place. The private key sweep builds its own PSBT from a key that is not in
+     * a wallet, so it cannot come through here; it asks the chain the same question directly, since a key
+     * it holds has no signer to declare for.
      *
      * The wallet does not offer a control for forcing this on. Every input to the decision that it can
      * establish, it establishes more reliably than a person: whether the chain has reached the height,
@@ -1343,7 +1344,7 @@ public class AppServices {
         return applyUnifiedSigHash(walletTransaction.createPSBT(), active);
     }
 
-    static PSBT applyUnifiedSigHash(PSBT psbt, boolean active) {
+    public static PSBT applyUnifiedSigHash(PSBT psbt, boolean active) {
         if(active) {
             for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
                 SigHash sigHash = psbtInput.getSigHash();

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -1265,26 +1265,27 @@ public class AppServices {
     }
 
     /**
-     * Every caveat that applies, in the order they qualify the opt-in.
+     * The decision, with every caveat that applies rather than only the one the headline came from.
      *
-     * The decision above can only carry one, and on an Electrum connection both apply at once: no server reports an
-     * activation height, so an opt-in there is always uncorroborated, and a partially marked multisig adds its own.
-     * Reporting only the headline's caveat left the common configuration never told that a quorum of signers which
-     * cannot opt in would produce no protection.
+     * The decision can carry one, and on an Electrum connection both apply at once: no server reports an activation
+     * height, so an opt-in there is always uncorroborated, and a partially marked multisig adds its own. Reporting
+     * only the headline's caveat left the common configuration never told that a quorum of signers which cannot opt
+     * in would produce no protection.
      */
-    public static List<String> getUnifiedSigHashCaveats(Wallet wallet) {
+    public static UnifiedSigHashStatus getUnifiedSigHashStatus(Wallet wallet) {
+        //One read of the tip for both answers. Reading it again for the caveats would let the headline describe one
+        //tip and the caveats another, which is the same class of split reading the ChainTip record exists to prevent.
         ChainTip tip = announcedTip;
         UnifiedSigHashDecision chain = chainDecision(Network.get(), tip == null ? null : tip.height(), tip == null ? null : tip.header());
-        if(!chain.isOptedIn()) {
-            return List.of();
+        UnifiedSigHashDecision decision = combinedDecision(chain, wallet);
+
+        if(!decision.isOptedIn()) {
+            return new UnifiedSigHashStatus(decision, List.of());
         }
 
-        UnifiedSigHashDecision keystores = keystoreDecision(wallet);
-        if(!keystores.isOptedIn()) {
-            return List.of();
-        }
-
+        //Both may qualify the same opt-in, and only one of them could be the headline
         List<String> caveats = new ArrayList<>();
+        UnifiedSigHashDecision keystores = keystoreDecision(wallet);
         if(keystores.getCaveat() != null) {
             caveats.add(keystores.getCaveat() + markedSignerSuffix(wallet));
         }
@@ -1292,7 +1293,13 @@ public class AppServices {
             caveats.add(chain.getCaveat());
         }
 
-        return caveats;
+        return new UnifiedSigHashStatus(decision, List.copyOf(caveats));
+    }
+
+    /**
+     * The decision and everything qualifying it, taken from one reading of the chain tip so the two agree.
+     */
+    public record UnifiedSigHashStatus(UnifiedSigHashDecision decision, List<String> caveats) {
     }
 
     /**

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -845,16 +845,22 @@ public class AppServices {
             return UnifiedSigHashDecision.CHAIN_UNSEEN;
         }
 
+        Integer activationHeight = getUnifiedSigHashActivationHeight(network);
+
         //A v2 header means the proof of work change is live, and both rule sets activate at the one block
         if(!blockHeader.isHeaderV2()) {
-            return UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED;
+            //Nothing authenticates the announced tip, so a server that kept announcing pre-fork headers could hold
+            //the wallet at "not activated" indefinitely and every transaction it signed would be replayable. Where
+            //this build ships a height and the tip claims to be at or past it, the two cannot both be right, and
+            //saying so names the server rather than the chain.
+            return activationHeight != null && blockHeight != null && blockHeight >= activationHeight
+                    ? UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE : UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED;
         }
 
         if(network == Network.REGTEST) {
             return UnifiedSigHashDecision.OPTED_IN;
         }
 
-        Integer activationHeight = getUnifiedSigHashActivationHeight(network);
         //nodeHardforkHeight is read once here and passed by value. The callee null checks it and then
         //dereferences it, which is only safe because it cannot be cleared between those two steps.
         //Inlining this call so the field is read twice would reintroduce that race.

--- a/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
+++ b/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
@@ -156,7 +156,24 @@ public enum UnifiedSigHashDecision {
      * fork and commits to the amounts it spends, and one that predates both guarantees.
      */
     public String getSummary() {
+        //The conditional opt-in is the one answer the wallet cannot promise: it holds only where a signer that can
+        //opt in is among those that actually sign, and the user chooses that after this is displayed. Saying
+        //"Replay protected" here states as settled a thing that is still up to them.
+        if(this == OPTED_IN_IF_MARKED_SIGNS) {
+            return "Replay protected if a marked signer signs";
+        }
+
         return summaryFor(isOptedIn());
+    }
+
+    /**
+     * Whether the opt-in this reports is settled, rather than resting on who ends up signing.
+     *
+     * Drives the glyph: a guarantee earns the success mark, a condition does not, and the two reading the same on
+     * sight was how a partially marked multisig looked identical to a fully marked one.
+     */
+    public boolean isGuaranteed() {
+        return isOptedIn() && this != OPTED_IN_IF_MARKED_SIGNS;
     }
 
     /**

--- a/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
+++ b/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
@@ -70,6 +70,20 @@ public enum UnifiedSigHashDecision {
     SCHEDULE_MISMATCH("this build and the connected node disagree on the activation height"),
 
     /**
+     * The tip the server announced contradicts the schedule this build ships.
+     *
+     * The activation height and the header version activate together, so a tip at or above the height has to be a v2
+     * header. One that is not means the server is not following the chain this build is, whether it is behind, on
+     * another chain, or answering dishonestly. The announced tip arrives from a subscription and nothing
+     * authenticates it, so a server that wanted the wallet to stop opting in could simply keep announcing v1 headers;
+     * reported as the disagreement it is rather than as the chain not having activated, which would be a statement
+     * about the chain rather than about the answer.
+     */
+    TIP_CONTRADICTS_SCHEDULE("the connected server announced a tip that contradicts the activation height in this build",
+            "The tip it reports is at or past the activation height but is not a fork header. Check the server is "
+                    + "following the fork and is fully synced before sending."),
+
+    /**
      * Both agree on a height the chain has not reached yet.
      */
     BEFORE_ACTIVATION_HEIGHT("the chain has not reached the activation height"),

--- a/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
+++ b/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
@@ -42,7 +42,7 @@ public enum UnifiedSigHashDecision {
     /**
      * The tip is not a v2 header, so the proof of work change is not live and neither is this.
      */
-    CHAIN_NOT_ACTIVATED("the chain has not activated it"),
+    CHAIN_NOT_ACTIVATED("the fork is not active on this chain yet"),
 
     /**
      * No tip to read at all, which is every offline session and the moment before the first one arrives.

--- a/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
@@ -485,6 +485,11 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
             psbtInput.setWitnessUtxo(utxoOutput);
         }
 
+        //A swept key signs here, from a key this dialog holds, so there is no device to be marked and nothing to
+        //declare for: the chain is the whole question. Without this the sweep was the one signing path in the
+        //application that never opted in, and it said nothing about it either.
+        AppServices.applyUnifiedSigHash(psbt, AppServices.isUnifiedSigHashActive());
+
         for(int i = 0; i < txOutputs.size(); i++) {
             TransactionOutput utxoOutput = txOutputs.get(i);
             TransactionInput txInput = transaction.getInputs().get(i);

--- a/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/PrivateKeySweepDialog.java
@@ -432,6 +432,24 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         return txOutputs.stream().filter(txOutput -> txOutput.getValue() > dustAttackThreshold).collect(Collectors.toList());
     }
 
+    /**
+     * The PSBT a sweep signs, with the witness UTXOs every input needs and the hash type it will declare.
+     *
+     * A swept key signs here, from a key this dialog holds, so there is no device to be marked and nothing to declare
+     * for: the chain is the whole question. Without the opt-in this was the one signing path in the application that
+     * never took it, and it said nothing about that either. Separated from the dialog so the declaration can be
+     * tested without a JavaFX view, which is the only reason the fix would otherwise go uncovered.
+     */
+    static PSBT sweepPsbt(Transaction transaction, List<TransactionOutput> txOutputs, boolean optedIn) {
+        PSBT psbt = new PSBT(transaction);
+        //Set witness UTXOs on PSBT inputs first - they are all required when hashing for a Taproot signature
+        for(int i = 0; i < txOutputs.size(); i++) {
+            psbt.getPsbtInputs().get(i).setWitnessUtxo(txOutputs.get(i));
+        }
+
+        return AppServices.applyUnifiedSigHash(psbt, optedIn);
+    }
+
     private void createTransaction(ECKey privKey, ScriptType scriptType, List<TransactionOutput> txOutputs, Payment payment) {
         Address destAddress = payment instanceof SilentPayment silentPayment ? computeSilentPaymentAddress(privKey, scriptType, txOutputs, silentPayment) : payment.getAddress();
         ECKey pubKey = ECKey.fromPublicOnly(privKey);
@@ -439,7 +457,12 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         Transaction noFeeTransaction = new Transaction();
         long total = 0;
         for(TransactionOutput txOutput : txOutputs) {
-            scriptType.addSpendingInput(PolicyType.SINGLE_HD, noFeeTransaction, txOutput, pubKey, TransactionSignature.dummy(scriptType == P2TR ? TransactionSignature.Type.SCHNORR : TransactionSignature.Type.ECDSA));
+            //Sized for the opt-in, as Wallet does for its own inputs. A schnorr signature carrying a hash type is a
+            //byte longer than one taking the default, so a dummy built without it under-measures the weight of the
+            //transaction this dialog now signs, and the fee is taken off that measurement.
+            scriptType.addSpendingInput(PolicyType.SINGLE_HD, noFeeTransaction, txOutput,
+                    pubKey, TransactionSignature.dummy(scriptType == P2TR ? TransactionSignature.Type.SCHNORR : TransactionSignature.Type.ECDSA,
+                            SigHash.UNIFIED_ALL.value));
             total += txOutput.getValue();
         }
 
@@ -477,18 +500,7 @@ public class PrivateKeySweepDialog extends Dialog<Transaction> {
         }
         transaction.addOutput(new TransactionOutput(transaction, total - fee, destAddress.getOutputScript()));
 
-        PSBT psbt = new PSBT(transaction);
-        //Set witness UTXOs on PSBT inputs first - they are all required when hashing for a Taproot signature
-        for(int i = 0; i < txOutputs.size(); i++) {
-            TransactionOutput utxoOutput = txOutputs.get(i);
-            PSBTInput psbtInput = psbt.getPsbtInputs().get(i);
-            psbtInput.setWitnessUtxo(utxoOutput);
-        }
-
-        //A swept key signs here, from a key this dialog holds, so there is no device to be marked and nothing to
-        //declare for: the chain is the whole question. Without this the sweep was the one signing path in the
-        //application that never opted in, and it said nothing about it either.
-        AppServices.applyUnifiedSigHash(psbt, AppServices.isUnifiedSigHashActive());
+        PSBT psbt = sweepPsbt(transaction, txOutputs, AppServices.isUnifiedSigHashActive());
 
         for(int i = 0; i < txOutputs.size(); i++) {
             TransactionOutput utxoOutput = txOutputs.get(i);

--- a/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashKeystoreDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashKeystoreDialog.java
@@ -38,13 +38,11 @@ public class UnifiedSigHashKeystoreDialog extends Dialog<List<Keystore>> {
                 A device reports its model but not its firmware, so only you can say which of these support the \
                 opt-in.
 
-                Leave one unmarked if you are unsure. A device marked that does not support it signs nothing rather \
-                than falling back. This applies to transactions created from now on.""");
+                Leave a signer unmarked if you are unsure. If you mark one that does not support the opt-in, it will \
+                refuse to sign rather than fall back. This applies to transactions created from now on.""");
         dialogPane.getStylesheets().add(AppServices.class.getResource("general.css").toExternalForm());
         dialogPane.getButtonTypes().addAll(ButtonType.CANCEL);
         dialogPane.setPrefWidth(560);
-        //Sized for the header, a line per keystore and the line counting them. A fixed height clipped the counting
-        //line once it was added, and clipped further the more keystores a wallet holds.
         //Sized for the header, a line per keystore and the line counting them, so nothing is clipped and nothing
         //is left as empty space below the buttons
         dialogPane.setPrefHeight(255 + (wallet.getKeystores().size() * 30));

--- a/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashKeystoreDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashKeystoreDialog.java
@@ -60,7 +60,11 @@ public class UnifiedSigHashKeystoreDialog extends Dialog<List<Keystore>> {
         //hardware here left the send screen offering a remedy this dialog had no control for.
         for(Keystore keystore : wallet.getKeystores()) {
             if(AppServices.canBeMarked(keystore)) {
-                CheckBox mark = new CheckBox(keystore.getLabel() + " (" + keystore.getWalletModel().toDisplayString() + ")");
+                //The parenthetical names the device. A watch only keystore has no device, and its walletModel defaults to
+                //the application's own name, which read as though Sparrow were the signer.
+                CheckBox mark = new CheckBox(keystore.getSource().isHardware()
+                        ? keystore.getLabel() + " (" + keystore.getWalletModel().toDisplayString() + ")"
+                        : keystore.getLabel());
                 mark.setSelected(keystore.isUnifiedSigHashSupported());
                 marks.put(keystore, mark);
                 content.getChildren().add(mark);

--- a/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashKeystoreDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashKeystoreDialog.java
@@ -57,8 +57,11 @@ public class UnifiedSigHashKeystoreDialog extends Dialog<List<Keystore>> {
         final VBox content = new VBox(10);
         //Indented to line up with the header text above it, rather than sitting against the edge of the pane
         content.setPadding(new Insets(4, 20, 0, 20));
+        //Every keystore the owner can speak for, which is the same set the keystore tab shows the field on. A watch
+        //only keystore is in the position an airgapped one is: the wallet cannot verify the claim, and listing only
+        //hardware here left the send screen offering a remedy this dialog had no control for.
         for(Keystore keystore : wallet.getKeystores()) {
-            if(keystore.getSource().isHardware()) {
+            if(AppServices.canBeMarked(keystore)) {
                 CheckBox mark = new CheckBox(keystore.getLabel() + " (" + keystore.getWalletModel().toDisplayString() + ")");
                 mark.setSelected(keystore.isUnifiedSigHashSupported());
                 marks.put(keystore, mark);
@@ -72,14 +75,18 @@ public class UnifiedSigHashKeystoreDialog extends Dialog<List<Keystore>> {
             progress.setWrapText(true);
             progress.setPadding(new Insets(12, 0, 6, 0));
             Runnable update = () -> {
-                long marked = marks.values().stream().filter(CheckBox::isSelected).count();
-                long unmarked = wallet.getKeystores().size() - marked;
+                //Counted the way the decision counts it: a keystore holding its own key opts in without being marked,
+                //so it is capable whether or not it appears above. Deriving this from the ticked boxes alone reported
+                //a wallet that mixes a seed with a device as less protected than it is.
+                long capable = wallet.getKeystores().stream().filter(keystore -> AppServices.signsInProcess(keystore)
+                        || (marks.containsKey(keystore) && marks.get(keystore).isSelected())).count();
+                long unmarked = wallet.getKeystores().size() - capable;
                 Integer threshold = AppServices.readThreshold(wallet);
                 int required = threshold == null ? 1 : threshold;
 
                 //Three answers, not two: nothing marked cannot opt in at all, a marked signer in every possible quorum
                 //is a guarantee, and anything between opts in but only protects where one of them signs
-                boolean any = marked > 0;
+                boolean any = capable > 0;
                 boolean guaranteed = any && unmarked < required;
 
                 //Carries the same glyph and colour the send screen uses for the same answer, so the two agree on sight
@@ -87,8 +94,8 @@ public class UnifiedSigHashKeystoreDialog extends Dialog<List<Keystore>> {
                 progress.getStyleClass().removeAll("success", "failure");
                 progress.getStyleClass().add(any ? "success" : "failure");
                 progress.setText((guaranteed ? "Transactions will opt in. "
-                        : any ? "Transactions opt in when a marked signer signs. " : "Transactions will not opt in. ")
-                        + marked + " of " + wallet.getKeystores().size() + " marked"
+                        : any ? "Transactions opt in when a signer that can opt in takes part. " : "Transactions will not opt in. ")
+                        + capable + " of " + wallet.getKeystores().size() + " signers can opt in"
                         + (threshold == null ? "." : ", " + threshold + " needed to sign."));
             };
             marks.values().forEach(mark -> mark.selectedProperty().addListener((observable, was, is) -> update.run()));

--- a/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashStatusLabel.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/UnifiedSigHashStatusLabel.java
@@ -17,9 +17,12 @@ import javafx.scene.control.Tooltip;
  */
 public class UnifiedSigHashStatusLabel extends Label {
     public UnifiedSigHashStatusLabel(UnifiedSigHashScheduleEvent event) {
-        getStyleClass().add("unified-sighash-status");
         setPadding(OsType.getCurrent() == OsType.WINDOWS ? new Insets(0, 0, 1, 3) : new Insets(1, 0, 0, 3));
         setGraphic(GlyphUtils.getWarningGlyph());
+        //Shown only on a disagreement, which is the state where nothing this wallet sends opts in. That is worth
+        //words rather than an unlabelled icon: the tooltip explains why, but a warning triangle on its own leaves
+        //the one consequence that matters to be discovered by hovering.
+        setText("No replay protection");
         update(event);
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -584,10 +584,14 @@ public class HeadersController extends TransactionFormController implements Init
                     SigHash chosen = newValue == SigHash.DEFAULT && !psbtInput.isTaproot() ? SigHash.ALL : newValue;
                     //The control offers one type for the whole transaction and its items are all opted in or all not,
                     //taken from the first input that declares one. A PSBT can carry a different type per input, so
-                    //writing the chosen one straight out would strip the opt-in from any other input that had it.
-                    //What is being chosen here is the output type; whether an input opted in stays the input's own.
+                    //writing the chosen one straight out moves the opt-in on any input that differs from the first.
+                    //What is being chosen here is the output type; whether an input opted in stays the input's own,
+                    //in both directions.
                     SigHash existing = psbtInput.getSigHash();
-                    psbtInput.setSigHash(existing != null && existing.isUnified() ? chosen.withUnified() : chosen);
+                    if(existing != null) {
+                        chosen = existing.isUnified() ? chosen.withUnified() : chosen.withoutUnified();
+                    }
+                    psbtInput.setSigHash(chosen);
                 }
             });
 
@@ -976,14 +980,6 @@ public class HeadersController extends TransactionFormController implements Init
     }
 
     /**
-     * Shows what the transaction's signatures do, and nothing about why.
-     *
-     * Deliberately without a reason. A PSBT records only the hash type its inputs carry, so the reason a
-     * particular one was not opted in is not in it to read, and a PSBT from a co-signer never had one to
-     * begin with. Recomputing this wallet's own decision here would answer a different question than the
-     * one the transaction is being asked, and would put a second copy of that decision in the view.
-     */
-    /**
      * Recomputes the status once signatures have landed. The declared hash type is only the answer while nothing has
      * signed yet: a quorum of unmarked cosigners is handed the base type, so a transaction that declared the opt-in
      * can finish carrying none of it. Reporting the declaration after that would say protected over a transaction
@@ -995,6 +991,14 @@ public class HeadersController extends TransactionFormController implements Init
         }
     }
 
+    /**
+     * Shows what the transaction's signatures do, and nothing about why.
+     *
+     * Deliberately without a reason. A PSBT records only the hash type its inputs carry, so the reason a
+     * particular one was not opted in is not in it to read, and a PSBT from a co-signer never had one to
+     * begin with. Recomputing this wallet's own decision here would answer a different question than the
+     * one the transaction is being asked, and would put a second copy of that decision in the view.
+     */
     private void updateOptInStatus(SigHash psbtSigHash) {
         //Counted off the signatures rather than taken from the declared hash type, because a transaction assembled
         //from per-device PSBTs carries signatures the declaration does not describe

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -581,7 +581,13 @@ public class HeadersController extends TransactionFormController implements Init
                 }
 
                 for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
-                    psbtInput.setSigHash(newValue == SigHash.DEFAULT && !psbtInput.isTaproot() ? SigHash.ALL : newValue);
+                    SigHash chosen = newValue == SigHash.DEFAULT && !psbtInput.isTaproot() ? SigHash.ALL : newValue;
+                    //The control offers one type for the whole transaction and its items are all opted in or all not,
+                    //taken from the first input that declares one. A PSBT can carry a different type per input, so
+                    //writing the chosen one straight out would strip the opt-in from any other input that had it.
+                    //What is being chosen here is the output type; whether an input opted in stays the input's own.
+                    SigHash existing = psbtInput.getSigHash();
+                    psbtInput.setSigHash(existing != null && existing.isUnified() ? chosen.withUnified() : chosen);
                 }
             });
 

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1025,7 +1025,9 @@ public class HeadersController extends TransactionFormController implements Init
         }
 
         if(everySignature || signatures == 0) {
-            return "These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and they commit to the amounts they spend.";
+            //"the amount it spends" rather than "the amounts they spend": an Anyone Can Pay signature commits to its
+            //own input's amount and no other, so the blanket claim was not true of one.
+            return "These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and each commits to the amount it spends.";
         }
 
         String detail = "This transaction cannot be replayed against nodes that have not adopted the fork: one signature that opts in is enough, and "

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -977,6 +977,18 @@ public class HeadersController extends TransactionFormController implements Init
      * begin with. Recomputing this wallet's own decision here would answer a different question than the
      * one the transaction is being asked, and would put a second copy of that decision in the view.
      */
+    /**
+     * Recomputes the status once signatures have landed. The declared hash type is only the answer while nothing has
+     * signed yet: a quorum of unmarked cosigners is handed the base type, so a transaction that declared the opt-in
+     * can finish carrying none of it. Reporting the declaration after that would say protected over a transaction
+     * that is not.
+     */
+    private void refreshOptInStatus() {
+        if(headersForm.getPsbt() != null) {
+            updateOptInStatus(sigHash.getValue());
+        }
+    }
+
     private void updateOptInStatus(SigHash psbtSigHash) {
         //Counted off the signatures rather than taken from the declared hash type, because a transaction assembled
         //from per-device PSBTs carries signatures the declaration does not describe
@@ -1278,6 +1290,7 @@ public class HeadersController extends TransactionFormController implements Init
             }
             unencryptedWallet.sign(signingNodes);
             updateSignedKeystores(headersForm.getSigningWallet());
+            refreshOptInStatus();
         } catch(Exception e) {
             log.warn("Failed to Sign", e);
             AppServices.showErrorDialog("Failed to Sign", e.getMessage());
@@ -1813,6 +1826,9 @@ public class HeadersController extends TransactionFormController implements Init
                 finalizePSBT();
                 EventManager.get().post(new FinalizeTransactionEvent(headersForm.getPsbt(), signedWallet));
             }
+
+            //A combine is where a cosigner's signatures arrive, so it is where the count this reports changes
+            refreshOptInStatus();
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
@@ -408,8 +408,10 @@ public class KeystoreController extends WalletFormController implements Initiali
         //nothing to declare for those. Refreshed here rather than at setup so that replacing the keystore with
         //another source shows the right thing
         unifiedSigHashField.setVisible(AppServices.canBeMarked(keystore));
+        //Phrased as the owner's confirmation, because that is what it is. The wallet cannot detect this, and a
+        //control reading "Supported by this device" states it as a fact the wallet established.
         unifiedSigHash.setText(keystore.getSource().isHardware()
-                ? "Supported by this device" : "Supported by the signer for this keystore");
+                ? "I confirm this device supports it" : "I confirm the signer for this keystore supports it");
         refreshingUnifiedSigHash = true;
         try {
             unifiedSigHash.setSelected(keystore.isUnifiedSigHashSupported());

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
@@ -821,18 +821,36 @@ public class KeystoreController extends WalletFormController implements Initiali
      */
     @Subscribe
     public void keystoreUnifiedSigHashChanged(KeystoreUnifiedSigHashChangedEvent event) {
-        if(event.getWalletId().equals(walletForm.getWalletId())) {
-            for(Keystore changedKeystore : event.getChangedKeystores()) {
-                if(changedKeystore.getExtendedPublicKey() != null && keystore.getExtendedPublicKey() != null
-                        && changedKeystore.getExtendedPublicKey().equals(keystore.getExtendedPublicKey())
-                        && keystore.isUnifiedSigHashSupported() != changedKeystore.isUnifiedSigHashSupported()) {
-                    keystore.setUnifiedSigHashSupported(changedKeystore.isUnifiedSigHashSupported());
-                    refreshingUnifiedSigHash = true;
-                    try {
-                        unifiedSigHash.setSelected(changedKeystore.isUnifiedSigHashSupported());
-                    } finally {
-                        refreshingUnifiedSigHash = false;
-                    }
+        if(!event.getWalletId().equals(walletForm.getWalletId())) {
+            return;
+        }
+
+        //EventBus dispatches on the thread that posted. Both posters are on the FX thread today, and this touches the
+        //scene graph, so it says so rather than resting on that staying true.
+        if(!Platform.isFxApplicationThread()) {
+            Platform.runLater(() -> keystoreUnifiedSigHashChanged(event));
+            return;
+        }
+
+        //Matched by position, because the diff this exists to protect matches by position too
+        //(SettingsWalletForm.getUnifiedSigHashChangedKeystores walks both keystore lists by index). Matching on the
+        //extended public key instead would silently do nothing whenever the copy's key has been edited in this very
+        //tab, which is exactly when the stale value is about to be written back.
+        int index = walletForm.getWallet().getKeystores().indexOf(keystore);
+        if(index < 0) {
+            return;
+        }
+
+        List<Keystore> eventKeystores = event.getWallet().getKeystores();
+        for(Keystore changedKeystore : event.getChangedKeystores()) {
+            if(eventKeystores.indexOf(changedKeystore) == index
+                    && keystore.isUnifiedSigHashSupported() != changedKeystore.isUnifiedSigHashSupported()) {
+                keystore.setUnifiedSigHashSupported(changedKeystore.isUnifiedSigHashSupported());
+                refreshingUnifiedSigHash = true;
+                try {
+                    unifiedSigHash.setSelected(changedKeystore.isUnifiedSigHashSupported());
+                } finally {
+                    refreshingUnifiedSigHash = false;
                 }
             }
         }

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/KeystoreController.java
@@ -811,6 +811,31 @@ public class KeystoreController extends WalletFormController implements Initiali
         }
     }
 
+    /**
+     * The settings tab edits a copy of the wallet, taken once when the tab was built. The mark can also be set from
+     * the send screen, which writes and persists it on the real wallet, and the copy does not hear about it. Applying
+     * any later change from this tab would then diff a stale value against the new one and write the old mark back,
+     * silently unmarking a keystore the user had just marked. Kept in step here, the way the label is.
+     */
+    @Subscribe
+    public void keystoreUnifiedSigHashChanged(KeystoreUnifiedSigHashChangedEvent event) {
+        if(event.getWalletId().equals(walletForm.getWalletId())) {
+            for(Keystore changedKeystore : event.getChangedKeystores()) {
+                if(changedKeystore.getExtendedPublicKey() != null && keystore.getExtendedPublicKey() != null
+                        && changedKeystore.getExtendedPublicKey().equals(keystore.getExtendedPublicKey())
+                        && keystore.isUnifiedSigHashSupported() != changedKeystore.isUnifiedSigHashSupported()) {
+                    keystore.setUnifiedSigHashSupported(changedKeystore.isUnifiedSigHashSupported());
+                    refreshingUnifiedSigHash = true;
+                    try {
+                        unifiedSigHash.setSelected(changedKeystore.isUnifiedSigHashSupported());
+                    } finally {
+                        refreshingUnifiedSigHash = false;
+                    }
+                }
+            }
+        }
+    }
+
     @Subscribe
     public void keystoreLabelsChanged(KeystoreLabelsChangedEvent event) {
         if(event.getWalletId().equals(walletForm.getWalletId())) {

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1094,6 +1094,9 @@ public class SendController extends WalletFormController implements Initializabl
         }
     }
 
+    //Guards the re-entrancy described on updateOptInStatus below
+    private boolean updatingOptInStatus;
+
     /**
      * Shows what this transaction's signatures will do and, where the wallet declined, why.
      *
@@ -1102,6 +1105,24 @@ public class SendController extends WalletFormController implements Initializabl
      * the same call decides what createPSBT will do when this transaction is created.
      */
     private void updateOptInStatus(WalletTransaction walletTransaction) {
+        //Asking for the decision can post a UnifiedSigHashScheduleEvent, which EventBus dispatches synchronously and
+        //this controller subscribes to, so this method can re-enter itself. It terminates today only because the
+        //report those posts are keyed on has already been recorded by the time the inner call runs, which makes a
+        //dedupe written for log noise load bearing for termination. Said here instead, and the inner pass would
+        //render the label only for the outer one to overwrite it.
+        if(updatingOptInStatus) {
+            return;
+        }
+
+        updatingOptInStatus = true;
+        try {
+            renderOptInStatus(walletTransaction);
+        } finally {
+            updatingOptInStatus = false;
+        }
+    }
+
+    private void renderOptInStatus(WalletTransaction walletTransaction) {
         if(walletTransaction == null) {
             optInStatus.setVisible(false);
             optInStatus.setTooltip(null);
@@ -1131,7 +1152,7 @@ public class SendController extends WalletFormController implements Initializabl
 
         StringBuilder detail = new StringBuilder();
         if(decision.isOptedIn()) {
-            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and they commit to the amounts they spend.");
+            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and each commits to the amount it spends.");
             //Every caveat that applies, not only the one the headline came from: on an Electrum connection a
             //partially marked multisig has two, and the one the headline dropped is the actionable one
             for(String caveat : status.caveats()) {
@@ -1171,8 +1192,9 @@ public class SendController extends WalletFormController implements Initializabl
             keystore.setUnifiedSigHashSupported(dialog.isMarked(keystore));
         }
 
+        //Dispatched synchronously, and this controller subscribes to it, so that handler is what refreshes the
+        //status. Calling it here as well rendered the label twice for one change.
         EventManager.get().post(new KeystoreUnifiedSigHashChangedEvent(wallet, pastWallet, getWalletForm().getWalletId(), changed.get()));
-        updateOptInStatus(walletTransactionProperty.get());
     }
 
     public void clear(ActionEvent event) {
@@ -1580,13 +1602,6 @@ public class SendController extends WalletFormController implements Initializabl
     }
 
     /**
-     * The status describes a decision made from the chain tip and the node's schedule, neither of which this
-     * controller owns. Rendered only when the transaction changed, it goes stale the moment either moves: a node
-     * upgraded mid-session reports a new activation height, the disagreement clears, and the screen carries on
-     * saying the two disagree while the transaction it builds is opted in. The label and the PSBT then say
-     * different things about the same send, and the label is the one that is wrong.
-     */
-    /**
      * The mark is the other input to this status, and it can be changed while a transaction is drafted: from the
      * keystore tab, or from the status label on this very screen. Without this the send screen keeps reporting the
      * answer the mark used to give, and it is stale in the unsafe direction, still saying protected after the
@@ -1604,6 +1619,13 @@ public class SendController extends WalletFormController implements Initializabl
         }
     }
 
+    /**
+     * The status describes a decision made from the chain tip and the node's schedule, neither of which this
+     * controller owns. Rendered only when the transaction changed, it goes stale the moment either moves: a node
+     * upgraded mid-session reports a new activation height, the disagreement clears, and the screen carries on
+     * saying the two disagree while the transaction it builds is opted in. The label and the PSBT then say
+     * different things about the same send, and the label is the one that is wrong.
+     */
     @Subscribe
     public void unifiedSigHashSchedule(UnifiedSigHashScheduleEvent event) {
         //EventBus dispatches on the thread that posted, which here is whichever thread dropped a connection or read

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1108,7 +1108,8 @@ public class SendController extends WalletFormController implements Initializabl
             return;
         }
 
-        UnifiedSigHashDecision decision = AppServices.getUnifiedSigHashDecision(walletTransaction.getWallet());
+        AppServices.UnifiedSigHashStatus status = AppServices.getUnifiedSigHashStatus(walletTransaction.getWallet());
+        UnifiedSigHashDecision decision = status.decision();
         optInStatus.setVisible(true);
         optInStatus.setText(decision.getSummary());
         //The success mark is for an answer that is settled. A conditional opt-in is not one, so it takes the warning
@@ -1133,7 +1134,7 @@ public class SendController extends WalletFormController implements Initializabl
             detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and they commit to the amounts they spend.");
             //Every caveat that applies, not only the one the headline came from: on an Electrum connection a
             //partially marked multisig has two, and the one the headline dropped is the actionable one
-            for(String caveat : AppServices.getUnifiedSigHashCaveats(walletTransaction.getWallet())) {
+            for(String caveat : status.caveats()) {
                 detail.append(System.lineSeparator()).append(System.lineSeparator()).append(caveat);
             }
         } else {

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1585,6 +1585,24 @@ public class SendController extends WalletFormController implements Initializabl
      * saying the two disagree while the transaction it builds is opted in. The label and the PSBT then say
      * different things about the same send, and the label is the one that is wrong.
      */
+    /**
+     * The mark is the other input to this status, and it can be changed while a transaction is drafted: from the
+     * keystore tab, or from the status label on this very screen. Without this the send screen keeps reporting the
+     * answer the mark used to give, and it is stale in the unsafe direction, still saying protected after the
+     * keystore that was providing it has been unmarked.
+     */
+    @Subscribe
+    public void keystoreUnifiedSigHashChanged(KeystoreUnifiedSigHashChangedEvent event) {
+        if(event.getWalletId().equals(getWalletForm().getWalletId())) {
+            if(!Platform.isFxApplicationThread()) {
+                Platform.runLater(() -> keystoreUnifiedSigHashChanged(event));
+                return;
+            }
+
+            updateOptInStatus(walletTransactionProperty.get());
+        }
+    }
+
     @Subscribe
     public void unifiedSigHashSchedule(UnifiedSigHashScheduleEvent event) {
         //EventBus dispatches on the thread that posted, which here is whichever thread dropped a connection or read

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1111,7 +1111,9 @@ public class SendController extends WalletFormController implements Initializabl
         UnifiedSigHashDecision decision = AppServices.getUnifiedSigHashDecision(walletTransaction.getWallet());
         optInStatus.setVisible(true);
         optInStatus.setText(decision.getSummary());
-        optInStatus.setGraphic(decision.isOptedIn() ? GlyphUtils.getSuccessGlyph() : GlyphUtils.getWarningGlyph());
+        //The success mark is for an answer that is settled. A conditional opt-in is not one, so it takes the warning
+        //glyph even though it did opt in.
+        optInStatus.setGraphic(decision.isGuaranteed() ? GlyphUtils.getSuccessGlyph() : GlyphUtils.getWarningGlyph());
 
         //The one decision the user can act on is offered here rather than only described: the send screen is where
         //they find out, and a setting reached by leaving the send and hunting through a tab is a setting nobody uses
@@ -1126,23 +1128,24 @@ public class SendController extends WalletFormController implements Initializabl
             optInStatus.setOnMouseClicked(null);
         }
 
-        Tooltip tooltip = new Tooltip(decision.isOptedIn()
-                ? "These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and they commit to the amounts they spend."
-                    + (decision.getCaveat() == null ? "" : System.lineSeparator() + System.lineSeparator() + decision.getCaveat()
-                        + namedSigners(walletTransaction))
-                : "Signing the way it always has been, because " + decision.getReason() + "."
-                    + (decision.getRemedy() == null ? "" : System.lineSeparator() + System.lineSeparator() + decision.getRemedy()));
+        StringBuilder detail = new StringBuilder();
+        if(decision.isOptedIn()) {
+            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and they commit to the amounts they spend.");
+            //Every caveat that applies, not only the one the headline came from: on an Electrum connection a
+            //partially marked multisig has two, and the one the headline dropped is the actionable one
+            for(String caveat : AppServices.getUnifiedSigHashCaveats(walletTransaction.getWallet())) {
+                detail.append(System.lineSeparator()).append(System.lineSeparator()).append(caveat);
+            }
+        } else {
+            detail.append("These signatures will be made the way they always have been, because ").append(decision.getReason()).append(".");
+            if(decision.getRemedy() != null) {
+                detail.append(System.lineSeparator()).append(System.lineSeparator()).append(decision.getRemedy());
+            }
+        }
+
+        Tooltip tooltip = new Tooltip(detail.toString());
         tooltip.setShowDuration(Duration.INDEFINITE);
         optInStatus.setTooltip(tooltip);
-    }
-
-    /**
-     * The signers that can produce the opt-in, appended to a caveat that would otherwise leave the reader to go
-     * and find out which ones those are.
-     */
-    private static String namedSigners(WalletTransaction walletTransaction) {
-        String names = walletTransaction == null ? null : AppServices.markedSignerNames(walletTransaction.getWallet());
-        return names == null ? "" : " Those are: " + names + ".";
     }
 
     /**
@@ -1584,6 +1587,13 @@ public class SendController extends WalletFormController implements Initializabl
      */
     @Subscribe
     public void unifiedSigHashSchedule(UnifiedSigHashScheduleEvent event) {
+        //EventBus dispatches on the thread that posted, which here is whichever thread dropped a connection or read
+        //a schedule off a node, so the scene graph work is marshalled rather than assumed
+        if(!Platform.isFxApplicationThread()) {
+            Platform.runLater(() -> unifiedSigHashSchedule(event));
+            return;
+        }
+
         updateOptInStatus(walletTransactionProperty.get());
     }
 

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/keystore.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/keystore.fxml
@@ -113,7 +113,7 @@
                 <TextArea fx:id="spScan" wrapText="true" prefRowCount="2" maxHeight="52" />
             </Field>
             <Field fx:id="unifiedSigHashField" text="Replay protection:">
-                <CheckBox fx:id="unifiedSigHash" text="Supported by this device" />
+                <CheckBox fx:id="unifiedSigHash" text="I confirm this device supports it" />
                 <HelpLabel helpText="Whether the signer behind this keystore produces the unified opt-in signature hash.\nA device reports its model but not its firmware, and a watch only keystore says nothing about what signs for it, so only you can say.\n\nLeave this off if you are unsure. A signature that does not opt in is valid under the pre-fork rules as well as the new ones, so it can be replayed against nodes that have not adopted the fork.\n\nTurning it on for a device that does not support it does not fall back: the device signs nothing and reports a failure of its own." />
             </Field>
         </Fieldset>

--- a/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
@@ -85,6 +85,57 @@ public class MixedWitnessCombineTest {
         }
     }
 
+    /**
+     * Checking each signature against the type it names must not become "any type verifies".
+     *
+     * The opt-in bit is the only thing a signer may differ on, because it is the only thing this wallet varies per
+     * signer. A signature over SIGHASH_NONE commits to no outputs at all, so accepting one where ALL was asked for
+     * would finalise a transaction anyone could redirect.
+     */
+    @Test
+    public void testASignatureOverATypeNobodyAskedForIsRefused() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = mixedWitnessPsbt(SigHash.ALL, SigHash.NONE);
+
+        //Both keys signed, over two different output types
+        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt)[1]);
+
+        Assertions.assertThrows(PSBTSignatureException.class, psbt::verifySignatures,
+                "a signature over a type the input never asked for must not verify");
+    }
+
+    /** The opt-in still travels with the declared type, which is the whole point of the per signature check. */
+    @Test
+    public void testTheOptInBitIsTheOneThingASignerMayDifferOn() throws Exception {
+        Network.set(Network.MAINNET);
+        //UNIFIED_ALL declared, one signature 0x21 and one 0x01: the shape psbtForDevice produces
+        mixedWitnessPsbt(SigHash.UNIFIED_ALL, SigHash.ALL).verifySignatures();
+        mixedWitnessPsbt(SigHash.ALL, SigHash.UNIFIED_ALL).verifySignatures();
+    }
+
+    /**
+     * A signer that answers with a different output type than it was handed must not clear the opt-in either. A
+     * taproot signer returning DEFAULT where ALL was asked for is the ordinary case, and matching only on the exact
+     * base type let that one through.
+     */
+    @Test
+    public void testAnUnrelatedTypeDoesNotClearTheOptIn() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = unsignedPsbt(SigHash.UNIFIED_ALL);
+
+        PSBT reply = psbt.copy();
+        for(PSBTInput psbtInput : reply.getPsbtInputs()) {
+            psbtInput.setSigHash(SigHash.DEFAULT);
+        }
+
+        psbt.combine(reply);
+
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertEquals(SigHash.UNIFIED_ALL, psbtInput.getSigHash(),
+                    "the opt-in survives a reply declaring any type without the bit");
+        }
+    }
+
     /** A real 2-of-2 P2WSH declaring one hash type, with nothing signed yet. */
     private PSBT unsignedPsbt(SigHash declared) throws Exception {
         Wallet wallet = twoOfTwo();

--- a/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
@@ -136,6 +136,71 @@ public class MixedWitnessCombineTest {
         }
     }
 
+    /**
+     * The mirror: a co-signer's PSBT must not add the opt-in either.
+     *
+     * Whether to opt in is this wallet's decision, taken from the chain it follows, and it only declines when it has
+     * a reason to. On a chain that has not reached the activation height an opted-in transaction is one the network
+     * holds and never mines, so honouring an outside byte there hands a counterparty the choice of what we sign.
+     */
+    @Test
+    public void testCombiningDoesNotAddAnOptInThisWalletDeclined() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = unsignedPsbt(SigHash.ALL);
+
+        PSBT reply = psbt.copy();
+        for(PSBTInput psbtInput : reply.getPsbtInputs()) {
+            psbtInput.setSigHash(SigHash.UNIFIED_ALL);
+        }
+
+        psbt.combine(reply);
+
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertEquals(SigHash.ALL, psbtInput.getSigHash(),
+                    "an incoming opt-in must not override the decision this wallet took");
+        }
+    }
+
+    /** The output type is still the co-signer's to change; only the opt-in bit is ours. */
+    @Test
+    public void testCombiningStillAdoptsTheIncomingOutputType() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = unsignedPsbt(SigHash.ALL);
+
+        PSBT reply = psbt.copy();
+        for(PSBTInput psbtInput : reply.getPsbtInputs()) {
+            psbtInput.setSigHash(SigHash.UNIFIED_NONE);
+        }
+
+        psbt.combine(reply);
+
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertEquals(SigHash.NONE, psbtInput.getSigHash(),
+                    "the output type moves, the opt-in does not");
+        }
+    }
+
+    /** Nothing declared here means there is no decision of this wallet's to preserve. */
+    @Test
+    public void testCombiningTakesTheIncomingTypeWhereNoneWasDeclared() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = unsignedPsbt(SigHash.UNIFIED_ALL);
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setSigHash(null);
+        }
+
+        PSBT reply = psbt.copy();
+        for(PSBTInput psbtInput : reply.getPsbtInputs()) {
+            psbtInput.setSigHash(SigHash.UNIFIED_ALL);
+        }
+
+        psbt.combine(reply);
+
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertEquals(SigHash.UNIFIED_ALL, psbtInput.getSigHash());
+        }
+    }
+
     /** A real 2-of-2 P2WSH declaring one hash type, with nothing signed yet. */
     private PSBT unsignedPsbt(SigHash declared) throws Exception {
         Wallet wallet = twoOfTwo();

--- a/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
@@ -1,0 +1,152 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.policy.Policy;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.*;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import com.sparrowwallet.drongo.psbt.PSBTSignatureException;
+import com.sparrowwallet.drongo.wallet.DeterministicSeed;
+import com.sparrowwallet.drongo.wallet.Keystore;
+import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.drongo.wallet.WalletNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A witness carrying one opted-in signature and one legacy signature is the shape the fork is built to
+ * produce: one marked signer is enough, and an unmarked cosigner is handed the base type so it can sign
+ * alongside. Verification has to check each signature against the type that signature names, not against
+ * the one the input happens to declare.
+ */
+public class MixedWitnessCombineTest {
+    @Test
+    public void testAMixedWitnessVerifies() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = mixedWitnessPsbt(SigHash.UNIFIED_ALL, SigHash.ALL);
+
+        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt)[1], "both keys must have signed");
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt)[0], "one of them opted in");
+
+        //The combine path and the parse path both run this. It must not reject a witness the finalise
+        //path is happy to build.
+        psbt.verifySignatures();
+    }
+
+    @Test
+    public void testAMixedWitnessVerifiesWhateverOrderItWasSignedIn() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = mixedWitnessPsbt(SigHash.ALL, SigHash.UNIFIED_ALL);
+
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt)[0], "one of them opted in");
+        psbt.verifySignatures();
+    }
+
+    /**
+     * An unmarked device is handed a copy asking for the base type, so the PSBT it returns declares the base type.
+     * Combining that back must not leave the input asking for the base type, or every signer that has not signed yet
+     * is asked for the legacy digest and the transaction finishes with no protection at all.
+     */
+    @Test
+    public void testCombiningAnUnmarkedDevicesReplyKeepsTheOptIn() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = unsignedPsbt(SigHash.UNIFIED_ALL);
+
+        PSBT forUnmarked = psbt.copy();
+        for(PSBTInput psbtInput : forUnmarked.getPsbtInputs()) {
+            psbtInput.setSigHash(SigHash.ALL);
+        }
+
+        psbt.combine(forUnmarked);
+
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertEquals(SigHash.UNIFIED_ALL, psbtInput.getSigHash(),
+                    "the opt-in must survive a reply from a device that was asked for the base type");
+        }
+    }
+
+    /** Combining a genuine change of type, rather than the downgrade above, still takes effect. */
+    @Test
+    public void testCombiningStillAdoptsADifferentType() throws Exception {
+        Network.set(Network.MAINNET);
+        PSBT psbt = unsignedPsbt(SigHash.UNIFIED_ALL);
+
+        PSBT other = psbt.copy();
+        for(PSBTInput psbtInput : other.getPsbtInputs()) {
+            psbtInput.setSigHash(SigHash.UNIFIED_NONE);
+        }
+
+        psbt.combine(other);
+
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertEquals(SigHash.UNIFIED_NONE, psbtInput.getSigHash());
+        }
+    }
+
+    /** A real 2-of-2 P2WSH declaring one hash type, with nothing signed yet. */
+    private PSBT unsignedPsbt(SigHash declared) throws Exception {
+        Wallet wallet = twoOfTwo();
+        PSBT psbt = psbtFor(wallet);
+        psbt.getPsbtInputs().getFirst().setSigHash(declared);
+        return psbt;
+    }
+
+    /** A real 2-of-2 P2WSH signed once per hash type, the way per-device PSBTs combine. */
+    private PSBT mixedWitnessPsbt(SigHash firstType, SigHash secondType) throws Exception {
+        Wallet wallet = twoOfTwo();
+        PSBT psbt = psbtFor(wallet);
+        PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
+
+        DeterministicSeed second = wallet.getKeystores().get(1).getSeed();
+        wallet.getKeystores().get(1).setSeed(null);
+        psbtInput.setSigHash(firstType);
+        wallet.sign(psbt);
+
+        wallet.getKeystores().get(1).setSeed(second);
+        DeterministicSeed first = wallet.getKeystores().getFirst().getSeed();
+        wallet.getKeystores().getFirst().setSeed(null);
+        psbtInput.setSigHash(secondType);
+        wallet.sign(psbt);
+        wallet.getKeystores().getFirst().setSeed(first);
+
+        return psbt;
+    }
+
+    private Wallet twoOfTwo() throws Exception {
+        String[] mnemonics = {
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor",
+                "sample vibrant sound quantum ripple hidden pluck raven mirror ocean fabric noodle"};
+
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.MULTI_HD);
+        wallet.setScriptType(ScriptType.P2WSH);
+        for(String mnemonic : mnemonics) {
+            DeterministicSeed seed = new DeterministicSeed(mnemonic, "", 0, DeterministicSeed.Type.BIP39);
+            wallet.getKeystores().add(Keystore.fromSeed(seed, PolicyType.MULTI_HD, ScriptType.P2WSH.getDefaultDerivation()));
+        }
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, ScriptType.P2WSH, wallet.getKeystores(), 2));
+        wallet.getNode(KeyPurpose.RECEIVE);
+
+        return wallet;
+    }
+
+    private PSBT psbtFor(Wallet wallet) {
+        WalletNode receiveNode = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script spk = wallet.getOutputScript(receiveNode);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000001"), 0, new Script(new byte[0]));
+        transaction.getInputs().getFirst().setSequenceNumber(0xFFFFFFFEL);
+        transaction.addOutput(90000L, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100000L, spk.getProgram()));
+        psbtInput.setWitnessScript(ScriptType.MULTISIG.getOutputScript(2, receiveNode.getPubKeys()));
+
+        return psbt;
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/SweptKeyOptInTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/SweptKeyOptInTest.java
@@ -1,0 +1,75 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.*;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A swept key signs in process, from a key the sweep dialog holds, so there is no signer to declare for and the
+ * chain is the whole question. The dialog builds its own PSBT rather than going through createPSBT, which is why the
+ * shape it builds is pinned here: it was the one signing path in the application that never opted in.
+ */
+public class SweptKeyOptInTest {
+    @AfterEach
+    public void tearDown() {
+        Network.set(null);
+    }
+
+    @Test
+    public void testASweptKeySignsTheOptInWhenTheChainHasIt() throws Exception {
+        Network.set(Network.MAINNET);
+        ECKey privKey = ECKey.fromPrivate(new java.math.BigInteger(1, com.sparrowwallet.drongo.Utils.hexToBytes("a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90")), true);
+        PSBT psbt = sweepShapedPsbt(privKey);
+
+        AppServices.applyUnifiedSigHash(psbt, true);
+
+        PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
+        Assertions.assertEquals(SigHash.UNIFIED_ALL, psbtInput.getSigHash());
+        Assertions.assertTrue(psbtInput.sign(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, privKey)));
+
+        int[] counts = AppServices.signatureOptInCounts(psbt);
+        Assertions.assertEquals(1, counts[1], "the key signed");
+        Assertions.assertEquals(1, counts[0], "and it opted in");
+
+        //The signature has to verify against the digest its own byte names, or the node would refuse it
+        psbt.verifySignatures();
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(psbt));
+    }
+
+    /** Left alone before activation, so a sweep signs exactly as it did where the fork is not live. */
+    @Test
+    public void testASweptKeySignsTheOldWayWhereTheChainHasNot() throws Exception {
+        Network.set(Network.MAINNET);
+        ECKey privKey = ECKey.fromPrivate(new java.math.BigInteger(1, com.sparrowwallet.drongo.Utils.hexToBytes("a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90")), true);
+        PSBT psbt = sweepShapedPsbt(privKey);
+
+        AppServices.applyUnifiedSigHash(psbt, false);
+
+        PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
+        Assertions.assertNull(psbtInput.getSigHash(), "nothing declared, which signs the default");
+        Assertions.assertTrue(psbtInput.sign(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, privKey)));
+
+        Assertions.assertEquals(0, AppServices.signatureOptInCounts(psbt)[0], "no signature opted in");
+        psbt.verifySignatures();
+    }
+
+    /** The shape PrivateKeySweepDialog builds: one input spending a key it holds, one output, witness UTXO set. */
+    private PSBT sweepShapedPsbt(ECKey privKey) {
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, privKey);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000001"), 0, new Script(new byte[0]));
+        transaction.addOutput(90000L, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        psbt.getPsbtInputs().getFirst().setWitnessUtxo(new TransactionOutput(null, 100000L, spk.getProgram()));
+        return psbt;
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashDecisionTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashDecisionTest.java
@@ -2,6 +2,7 @@ package com.sparrowwallet.sparrow;
 
 import com.sparrowwallet.drongo.Network;
 import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.policy.Policy;
 import com.sparrowwallet.drongo.policy.PolicyType;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
 import com.sparrowwallet.drongo.protocol.ScriptType;
@@ -45,6 +46,19 @@ public class UnifiedSigHashDecisionTest {
 
     private BlockHeader header(String hex) {
         return new BlockHeader(Utils.hexToBytes(hex), 0);
+    }
+
+    private Wallet multisigWith(int threshold, KeystoreSource... sources) {
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.MULTI_HD);
+        wallet.setScriptType(ScriptType.P2WSH);
+        for(KeystoreSource source : sources) {
+            Keystore keystore = new Keystore();
+            keystore.setSource(source);
+            wallet.getKeystores().add(keystore);
+        }
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, ScriptType.P2WSH, wallet.getKeystores(), threshold));
+        return wallet;
     }
 
     private Wallet walletWith(KeystoreSource... sources) {
@@ -249,6 +263,48 @@ public class UnifiedSigHashDecisionTest {
             } else {
                 Assertions.assertNotNull(decision.getReason(), decision + " declined, so it owes a reason");
             }
+        }
+    }
+
+    /**
+     * Both caveats are reported, not only the one the headline came from.
+     *
+     * On an Electrum connection no server reports an activation height, so an opt-in there is always uncorroborated;
+     * a partially marked multisig adds its own. The decision can carry one of the two, and reporting only that one
+     * left the common configuration never told that a quorum of signers which cannot opt in produces no protection
+     * at all. The suffix naming the signers belongs to the quorum caveat alone: after the other it names nothing.
+     */
+    @Test
+    public void testEveryCaveatIsReportedNotOnlyTheHeadlines() {
+        Network.set(Network.TESTNET4);
+        try {
+            //A tip past activation with a fork header, and no node schedule, which is every Electrum connection
+            AppServices.setAnnouncedTip(new ChainTip(ACTIVATION, header(V2_HEADER_HEX)));
+            AppServices.clearNodeHardforkHeight();
+
+            Wallet conditional = multisigWith(2, KeystoreSource.HW_USB, KeystoreSource.HW_USB, KeystoreSource.HW_USB);
+            conditional.getKeystores().get(0).setLabel("Coldcard");
+            conditional.getKeystores().get(0).setUnifiedSigHashSupported(true);
+
+            AppServices.UnifiedSigHashStatus status = AppServices.getUnifiedSigHashStatus(conditional);
+            Assertions.assertEquals(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS, status.decision(),
+                    "the weaker of the two claims is the headline");
+            Assertions.assertEquals(2, status.caveats().size(),
+                    "both the quorum caveat and the uncorroborated one apply: " + status.caveats());
+
+            //The quorum caveat comes first and carries the signer names; the chain caveat carries none
+            Assertions.assertTrue(status.caveats().get(0).contains("Coldcard"), status.caveats().get(0));
+            Assertions.assertFalse(status.caveats().get(1).contains("Coldcard"), status.caveats().get(1));
+            Assertions.assertTrue(status.caveats().get(1).contains("activation height"), status.caveats().get(1));
+
+            //A fully marked wallet on the same connection carries the chain caveat only
+            Wallet marked = multisigWith(2, KeystoreSource.HW_USB, KeystoreSource.HW_USB, KeystoreSource.HW_USB);
+            marked.getKeystores().forEach(keystore -> keystore.setUnifiedSigHashSupported(true));
+            AppServices.UnifiedSigHashStatus markedStatus = AppServices.getUnifiedSigHashStatus(marked);
+            Assertions.assertEquals(UnifiedSigHashDecision.OPTED_IN_UNCORROBORATED, markedStatus.decision());
+            Assertions.assertEquals(1, markedStatus.caveats().size(), markedStatus.caveats().toString());
+        } finally {
+            AppServices.setAnnouncedTip(null);
         }
     }
 

--- a/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashDecisionTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashDecisionTest.java
@@ -59,10 +59,21 @@ public class UnifiedSigHashDecisionTest {
         return wallet;
     }
 
+    /**
+     * Below the activation height a pre-fork tip is the chain not having activated. At or above it the same tip
+     * contradicts the schedule this build ships, and the two cannot both be right, so it names the server instead.
+     */
     @Test
     public void testAV1TipIsReportedAsTheChainNotHavingActivated() {
         Assertions.assertEquals(UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED,
+                AppServices.chainDecision(Network.TESTNET4, ACTIVATION - 1, header(V1_HEADER_HEX)));
+
+        Assertions.assertEquals(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE,
                 AppServices.chainDecision(Network.TESTNET4, ACTIVATION, header(V1_HEADER_HEX)));
+
+        //Neither opts in, which is the part that decides what gets signed
+        Assertions.assertFalse(UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED.isOptedIn());
+        Assertions.assertFalse(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE.isOptedIn());
     }
 
     /**

--- a/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
@@ -685,6 +685,35 @@ public class UnifiedSigHashPolicyTest {
     }
 
     /**
+     * The case the test above does not reach: both caveats apply at once.
+     *
+     * Its quorum wallet marks two of three, so unmarked (1) is below the threshold (2) and the keystores return a
+     * plain OPTED_IN with no caveat to lose. Marking one of three is what produces a keystore caveat, and that is the
+     * common Electrum configuration, since no Electrum server reports an activation height.
+     */
+    @Test
+    public void testTheWeakerOfTwoCaveatsIsTheHeadline() {
+        Wallet conditional = multisigWith(2, KeystoreSource.HW_USB, KeystoreSource.HW_USB, KeystoreSource.HW_USB);
+        conditional.getKeystores().get(0).setUnifiedSigHashSupported(true);
+
+        Assertions.assertEquals(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS, AppServices.keystoreDecision(conditional),
+                "one marked of three, needing two, is conditional");
+
+        //A conditional opt-in can end in no protection at all, so it is the weaker claim and has to be the headline
+        Assertions.assertEquals(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS,
+                AppServices.combinedDecision(UnifiedSigHashDecision.OPTED_IN_UNCORROBORATED, conditional));
+        Assertions.assertEquals(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS,
+                AppServices.combinedDecision(UnifiedSigHashDecision.OPTED_IN, conditional));
+
+        //And it does not read as a settled answer
+        Assertions.assertTrue(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS.isOptedIn());
+        Assertions.assertFalse(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS.isGuaranteed());
+        Assertions.assertNotEquals(UnifiedSigHashDecision.OPTED_IN.getSummary(),
+                UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS.getSummary(),
+                "a condition must not read the same as a guarantee");
+    }
+
+    /**
      * The ordinary case, carried the same distance as the multisig one: a single signature wallet builds, signs and
      * finalises a spend whose signature opts in. Most wallets are this shape, and until now nothing in this project
      * signed one in process; the harness that did is a main method the suite never runs.

--- a/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
@@ -314,12 +314,17 @@ public class UnifiedSigHashPolicyTest {
 
     /**
      * The reason a user is shown has to point at the thing they can change, or the setting exists and
-     * nobody finds it. This is the only decision with anything to act on.
+     * nobody finds it. Equally, a decision with nothing to act on must not invent a remedy: a chain that has not
+     * reached its activation height is not something the user can do anything about, and saying otherwise sends
+     * them looking for a control that would not help.
+     *
+     * Three qualify. Two are the keystore mark, reached from the send screen and the keystore tab. The third is a
+     * server announcing a tip that cannot be true, where checking the server is exactly the action to take.
      */
     @Test
-    public void testOnlyTheUnmarkedDeviceReasonCarriesARemedy() {
-        List<UnifiedSigHashDecision> actionable =
-                List.of(UnifiedSigHashDecision.EXTERNAL_SIGNER, UnifiedSigHashDecision.NO_DEVICE_TO_MARK);
+    public void testOnlyReasonsWithSomethingToActOnCarryARemedy() {
+        List<UnifiedSigHashDecision> actionable = List.of(UnifiedSigHashDecision.EXTERNAL_SIGNER,
+                UnifiedSigHashDecision.NO_DEVICE_TO_MARK, UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE);
         for(UnifiedSigHashDecision decision : UnifiedSigHashDecision.values()) {
             if(actionable.contains(decision)) {
                 Assertions.assertNotNull(decision.getRemedy(), decision + " has something the user can act on");
@@ -1174,6 +1179,41 @@ public class UnifiedSigHashPolicyTest {
         Assertions.assertFalse(UnifiedSigHashDecision.CHAIN_UNSEEN.isOptedIn());
         Assertions.assertNull(UnifiedSigHashDecision.CHAIN_UNSEEN.getRemedy(),
                 "connecting is not something the wallet can do for the user, so no remedy is offered");
+    }
+
+    /**
+     * A tip that cannot be true is reported as the server disagreeing, not as the chain not having activated.
+     *
+     * Nothing authenticates the announced tip: it arrives from a subscription and is taken at face value. A server
+     * that kept announcing pre-fork headers would hold the wallet at "not activated" forever, and every transaction
+     * signed in that state is replayable. Where the tip claims a height at or past the one this build ships, a
+     * pre-fork header at that height contradicts the schedule and the wallet says so.
+     */
+    @Test
+    public void testATipThatContradictsTheScheduleIsReportedAsSuch() {
+        BlockHeader v1 = Network.MAINNET.getGenesisHeader();
+        Assertions.assertFalse(v1.isHeaderV2());
+
+        int activation = Network.MAINNET.getBlake2bHeight();
+
+        //Below the height a pre-fork header is exactly what the chain should have, and says nothing about the server
+        Assertions.assertEquals(UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED,
+                AppServices.chainDecision(Network.MAINNET, activation - 1, v1));
+
+        //At and past it the two cannot both be right
+        Assertions.assertEquals(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE,
+                AppServices.chainDecision(Network.MAINNET, activation, v1));
+        Assertions.assertEquals(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE,
+                AppServices.chainDecision(Network.MAINNET, activation + 5000, v1));
+
+        //It declines, and names something the user can actually check
+        Assertions.assertFalse(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE.isOptedIn());
+        Assertions.assertNotNull(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE.getReason());
+        Assertions.assertNotNull(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE.getRemedy());
+
+        //Regtest ships no height, so there is nothing for a tip to contradict
+        Assertions.assertEquals(UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED,
+                AppServices.chainDecision(Network.REGTEST, 5_000_000, v1));
     }
 
     /**

--- a/src/test/java/com/sparrowwallet/sparrow/control/SweptKeyOptInTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/SweptKeyOptInTest.java
@@ -1,6 +1,7 @@
-package com.sparrowwallet.sparrow;
+package com.sparrowwallet.sparrow.control;
 
 import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.drongo.crypto.ECKey;
 import com.sparrowwallet.drongo.policy.PolicyType;
 import com.sparrowwallet.drongo.protocol.*;
@@ -25,9 +26,7 @@ public class SweptKeyOptInTest {
     public void testASweptKeySignsTheOptInWhenTheChainHasIt() throws Exception {
         Network.set(Network.MAINNET);
         ECKey privKey = ECKey.fromPrivate(new java.math.BigInteger(1, com.sparrowwallet.drongo.Utils.hexToBytes("a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90")), true);
-        PSBT psbt = sweepShapedPsbt(privKey);
-
-        AppServices.applyUnifiedSigHash(psbt, true);
+        PSBT psbt = sweepPsbtFor(privKey, true);
 
         PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
         Assertions.assertEquals(SigHash.UNIFIED_ALL, psbtInput.getSigHash());
@@ -47,9 +46,7 @@ public class SweptKeyOptInTest {
     public void testASweptKeySignsTheOldWayWhereTheChainHasNot() throws Exception {
         Network.set(Network.MAINNET);
         ECKey privKey = ECKey.fromPrivate(new java.math.BigInteger(1, com.sparrowwallet.drongo.Utils.hexToBytes("a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90")), true);
-        PSBT psbt = sweepShapedPsbt(privKey);
-
-        AppServices.applyUnifiedSigHash(psbt, false);
+        PSBT psbt = sweepPsbtFor(privKey, false);
 
         PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
         Assertions.assertNull(psbtInput.getSigHash(), "nothing declared, which signs the default");
@@ -59,8 +56,8 @@ public class SweptKeyOptInTest {
         psbt.verifySignatures();
     }
 
-    /** The shape PrivateKeySweepDialog builds: one input spending a key it holds, one output, witness UTXO set. */
-    private PSBT sweepShapedPsbt(ECKey privKey) {
+    /** Built through the dialog's own seam, so removing the opt-in from it fails these. */
+    private PSBT sweepPsbtFor(ECKey privKey, boolean optedIn) {
         Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, privKey);
 
         Transaction transaction = new Transaction();
@@ -68,8 +65,7 @@ public class SweptKeyOptInTest {
         transaction.addInput(Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000001"), 0, new Script(new byte[0]));
         transaction.addOutput(90000L, spk);
 
-        PSBT psbt = new PSBT(transaction);
-        psbt.getPsbtInputs().getFirst().setWitnessUtxo(new TransactionOutput(null, 100000L, spk.getProgram()));
-        return psbt;
+        return PrivateKeySweepDialog.sweepPsbt(transaction,
+                java.util.List.of(new TransactionOutput(null, 100000L, spk.getProgram())), optedIn);
     }
 }


### PR DESCRIPTION
Fixes found by reviewing the fork against upstream before the next release, covering the replay protection status, the signing paths, and header validation. The drongo submodule is bumped to carry the verification and header fixes.

## The transaction could report protection it did not have

The transaction view computed its status when the tab opened, with no signatures present, and never recomputed it. Signing happens in that same tab. A quorum of cosigners that cannot opt in is handed the base type, so a transaction that declared the opt-in can finish carrying none of it, while the screen it is broadcast from still reads as protected. The status is now recomputed wherever signatures land.

## Reporting

A conditional opt-in in a partially marked multisig read identically to a guarantee, including the same success mark, though it holds only if a signer that can opt in is among those that sign. It now says so and takes a warning mark.

On any Electrum connection the multisig caveat was discarded entirely. No Electrum server reports an activation height, so an opt-in there is always uncorroborated, and only one of the two caveats could be the headline. Both are now reported, taken from a single reading of the chain tip so the headline and the caveats cannot describe different tips.

A server announcing a pre-fork tip at or past the activation height this build ships is now named as contradicting the schedule, rather than reported as the chain not having activated. Nothing authenticates the announced tip, so a server could otherwise hold the wallet at "not activated" indefinitely with every transaction it signed replayable.

## Watch only keystores

`canBeMarked` admits a watch only keystore, but the marking dialog listed hardware only and the PSBT downgrade tested only for hardware. The status label offered a remedy whose dialog opened empty. The three now agree, and the dialog counts what can opt in the way the decision counts it rather than rederiving it.

## Signing

The private key sweep built its own PSBT and never opted in, the only signing path that did not, and said nothing about it. A swept key signs in process, so there is no signer to declare for and the chain is the whole question. Its fee estimate is now sized for the signature it will produce.

The sighash control offers one type for the whole transaction, taken from the first input that declares one, and wrote that to every input. A PSBT can carry a different type per input, so this moved the opt-in on any input that differed. The output type is what the control chooses; the opt-in stays the input's own.

## Correctness around the status

Applying an unrelated change in wallet settings could write back a stale mark and silently unmark a keystore that had just been marked from the send screen, because the settings tab edits a copy taken once when the tab was built. The copy is now kept in step, matched by position as the diff that writes it back is.

The schedule handler mutated the scene graph on whichever thread posted the event, and the status handler could re-enter itself, terminating only because a dedupe written for log noise happened to stop it.

## Verification

998 tests. Nine end to end suites against a Bitcoin Knots `v29.4.1.knots20260508` node, covering the opt-in before and after activation, a mixed multisig witness, a marked watch only wallet signed externally, and the Anyone Can Pay lift. Header validation is checked against the real mainnet chain across its activation at 961640 and against 173 testnet4 headers across 150308. The critical fixes are mutation checked.
