### PR TITLE
Fold in upstream and bump to blake2b.19

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
@@ -20,7 +20,7 @@ public class SparrowWallet {
     public static final String APP_ID = "shrike";
     public static final String APP_NAME = "Shrike";
     public static final String APP_VERSION = "2.5.5";
-    public static final String APP_VERSION_SUFFIX = "-blake2b.18";
+    public static final String APP_VERSION_SUFFIX = "-blake2b.19";
     public static final String APP_HOME_PROPERTY = ApplicationDir.getHomeProperty(APP_NAME);
     public static final String NETWORK_ENV_PROPERTY = "SPARROW_NETWORK";
     public static final String JPACKAGE_APP_PATH = "jpackage.app-path";

--- a/src/main/java/com/sparrowwallet/sparrow/control/CoinTextFormatter.java
+++ b/src/main/java/com/sparrowwallet/sparrow/control/CoinTextFormatter.java
@@ -52,7 +52,8 @@ public class CoinTextFormatter extends TextFormatter<String> {
             }
 
             Matcher matcher = coinValidation.matcher(noFractionCommaText);
-            if(!matcher.matches()) {
+            boolean validAmount = matcher.matches();
+            if(!validAmount) {
                 matcher.reset();
                 if(matcher.find()) {
                     noFractionCommaText = matcher.group();
@@ -90,7 +91,8 @@ public class CoinTextFormatter extends TextFormatter<String> {
                     return change;
                 }
 
-                if(value.doubleValue() == 0.0 && "0".equals(correct)) {
+                //A zero value is left as entered so the fractional part can still be typed out, but only where the entire text is a valid amount
+                if(validAmount && value.doubleValue() == 0.0 && "0".equals(correct)) {
                     return change;
                 }
 

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -100,6 +100,13 @@ public class ElectrumServer {
     //Session cache of headers below the last pin, verified by hash linkage to it and deliberately never persisted
     static final Map<Integer, BlockHeader> verifiedHistoricalHeaders = new ConcurrentHashMap<>();
 
+    //Session cache of the transactions proven at a height, keyed by the pair proven. Kept across servers, since a proof reconstructs a header the
+    //compiled in checkpoints anchor rather than anything the server that supplied it vouches for, and dropped only where a reorg replaces the block
+    static final Map<String, BlockHeader> provenTransactionHeaders = new ConcurrentHashMap<>();
+
+    //Counts the rewinds of the header store, so that a proof can tell whether one happened while it was being obtained. Written under headerSyncLock
+    static volatile int reorgCount;
+
     //The deepest fork point the store has been rewound to this session, at or above which a stored height may have been proven against an orphaned
     //header. Written only under headerSyncLock, which is what makes the min in reconcile atomic; volatile is for the readers that do not take it
     static volatile int lastReorgForkHeight = Integer.MAX_VALUE;
@@ -1177,6 +1184,91 @@ public class ElectrumServer {
     }
 
     /**
+     * The header the given transaction is proven to be included in at the given height, or null where the connected server did not substantiate it,
+     * whether by declining the proof, answering for another block, or supplying a branch that does not reconstruct. For a transaction reached outside
+     * a wallet, where there is no history to demote and nothing to report per wallet: the caller has only the header to show, or its absence.
+     * <p>
+     * A server that does not implement the call at all disables verification for the session here as it does on the wallet paths, since a server
+     * lacking it substantiates nothing and marking every transaction against it unverified says something about the server that is not true.
+     */
+    public BlockHeader getProvenHeader(Sha256Hash txid, int height) throws ServerException {
+        String pair = txid + ":" + height;
+        BlockHeader provenHeader = provenTransactionHeaders.get(pair);
+        if(provenHeader != null) {
+            return provenHeader;    //a transaction reopened, or open in a second tab, and the answer cannot have changed while the block stands
+        }
+
+        BlockTransactionHash reference = new BlockTransaction(txid, height, null, null, null);
+        int reorgsBefore = reorgCount;
+        try {
+            Map<String, TransactionMerkleProof> proofs = electrumServerRpc.getTransactionMerkleProofs(getTransport(), null, List.of(reference));
+            TransactionMerkleProof proof = proofs.get(pair);
+            if(proof == null || proof == TransactionMerkleProof.ERROR_PROOF || proof.block_height != height) {
+                return null;
+            }
+
+            BlockHeader header = getVerifiedHeader(height);
+            if(header == null || !verifyProof(txid, proof, header)) {
+                return null;    //only what was proven is cached: a server that will not prove it now is not the server that will be asked next
+            }
+
+            //Remembered only where no reorg intervened, under the lock reconcile holds while it clears: a proof resolving across one would otherwise
+            //be written behind that clear, leaving an entry proven against a header the chain no longer holds. The proof itself still stands or falls
+            //on the header it reconstructed, so it is returned either way
+            synchronized(headerSyncLock) {
+                if(reorgCount == reorgsBefore) {
+                    provenTransactionHeaders.put(pair, header);
+                }
+            }
+
+            return header;
+        } catch(UnsupportedMethodException e) {
+            //Before the catch below, as elsewhere: a property of the server rather than of this transaction, so it is settled for the session on the
+            //same terms the wallet paths settle it, and raised rather than recorded where verification is mandatory
+            disableVerification(e);
+            return null;
+        } catch(ElectrumServerRpcException e) {
+            throw new ServerException(e.getMessage(), e.getCause());     //the server said nothing about this transaction, so it is a failed call
+        }
+    }
+
+    /**
+     * Whether a transaction carries the block it was proven to be in. The zero hash is not one: it marks a response that could not carry a height at
+     * all, and says nothing about a block.
+     */
+    public static boolean isProven(BlockTransaction blockTransaction) {
+        Sha256Hash blockHash = blockTransaction.getBlockHash();
+        return blockHash != null && !Sha256Hash.ZERO_HASH.equals(blockHash);
+    }
+
+    /**
+     * The given transaction carrying the block it was proven to be in, where this session has proved its height, and the transaction itself where it
+     * has not. The proof outlives the objects a wallet or a fetch hands out, none of which carry what was established after they were built, so what
+     * has been proven is asked here rather than read from whichever of them a form was last handed.
+     */
+    public static BlockTransaction getProvenTransaction(BlockTransaction blockTransaction) {
+        if(blockTransaction.getHeight() <= 0 || isProven(blockTransaction)) {
+            return blockTransaction;
+        }
+
+        BlockHeader provenHeader = provenTransactionHeaders.get(blockTransaction.getHashAsString() + ":" + blockTransaction.getHeight());
+        if(provenHeader == null) {
+            return blockTransaction;
+        }
+
+        return getProvenTransaction(blockTransaction, provenHeader);
+    }
+
+    /**
+     * The given transaction carrying the given block, for a caller holding the header a proof was verified against. What was proven is shown from the
+     * proof itself rather than from the cache above, which is an optimisation and does not remember a proof obtained across a reorg.
+     */
+    public static BlockTransaction getProvenTransaction(BlockTransaction blockTransaction, BlockHeader provenHeader) {
+        return new BlockTransaction(blockTransaction.getHash(), blockTransaction.getHeight(), provenHeader.getTimeAsDate(),
+                blockTransaction.getFee(), blockTransaction.getTransaction(), provenHeader.getHash());
+    }
+
+    /**
      * Whether the branch reconstructs the merkle root of the given verified header from the given transaction. Any malformed proof is a proof that
      * does not verify rather than a broken session.
      */
@@ -1534,6 +1626,9 @@ public class ElectrumServer {
         //one - only the current tip is replaced by the next announcement. Dropped with the headers they came from
         int reorganisedFrom = forkHeight;
         retrievedBlockHeaders.keySet().removeIf(height -> height > reorganisedFrom);
+        //Cleared whole rather than above the fork, the height being half of the key: a reorg is rare, and what it costs is one proof per transaction reopened
+        provenTransactionHeaders.clear();
+        reorgCount++;
         try {
             store.append(segment);
         } finally {
@@ -1689,7 +1784,7 @@ public class ElectrumServer {
      * against headers it also supplied establishes nothing it has not already been trusted for. Cormorant declares as much in its capability, but
      * bwt takes over where cormorant cannot start, and the same node should not verify or not according to which one did.
      */
-    static boolean isVerifyingTransactions() {
+    public static boolean isVerifyingTransactions() {
         if(!Config.get().isVerifyTransactions() || Config.get().getServerType() == ServerType.BITCOIN_CORE
                 || serverCapability == null || !serverCapability.supportsMerkleProofs()) {
             return false;
@@ -3676,6 +3771,38 @@ public class ElectrumServer {
                     }
 
                     return Collections.emptyMap();
+                }
+            };
+        }
+    }
+
+    /**
+     * Proves a transaction the tab is displaying, off the thread that fetched it: the proof is a round trip of its own, and the header it is checked
+     * against can cost a range fetch below the last pin, neither of which the transaction should wait behind to be shown.
+     * <p>
+     * Succeeding with no header is the server answering that it will not substantiate the height, which is a finding. Failing is not reaching the
+     * server at all, which is nothing, and the two are kept apart here so that the caller can tell what it has been told.
+     */
+    public static class TransactionVerificationService extends Service<BlockHeader> {
+        private final Sha256Hash txid;
+        private final int height;
+
+        public TransactionVerificationService(Sha256Hash txid, int height) {
+            this.txid = txid;
+            this.height = height;
+        }
+
+        @Override
+        protected Task<BlockHeader> createTask() {
+            return new Task<>() {
+                @Override
+                protected BlockHeader call() throws ServerException {
+                    //getTransport() opens one where there is none, so a task running after the connection closed must not reach it
+                    if(!isConnected()) {
+                        throw new ServerException("Not connected");
+                    }
+
+                    return new ElectrumServer().getProvenHeader(txid, height);
                 }
             };
         }

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -129,6 +129,9 @@ public class ElectrumServer {
 
     private static volatile boolean invalidTipWarned;
 
+    //Whether the connected server has announced a tip at or above the last pinned header, which the chain cannot then rewind below
+    static volatile boolean tipReachedCheckpoints;
+
     private static volatile long lastTipWarningLoggedAt;
 
     //A server refusing for capacity recovers within these attempts, one that cannot substantiate a height never does. Not final so tests need not wait
@@ -1678,8 +1681,9 @@ public class ElectrumServer {
      * setting is asked here so one answer covers the sync, both write boundaries and the connect time enforcement.
      * <p>
      * A server below the last pinned header cannot substantiate any height, so asking would refuse every new confirmation and raise a dialog for it.
-     * The public tier rejects such a server at connect; a private one still catching up simply goes unverified until it arrives. A tip not yet
-     * announced is not evidence of lagging.
+     * That accommodation is for a private server still catching up, and is not offered where verification is mandatory: such a server was already
+     * above the last pin when it was accepted at connect, so a later claim to be below it is not a server catching up, and its confirmations belong
+     * in the wallet no more than any other the server cannot prove. A tip not yet announced is not evidence of lagging.
      * <p>
      * Not asked of a Bitcoin Core connection at all, whichever backend is fronting it: the node answering is the user's own, and a proof it built
      * against headers it also supplied establishes nothing it has not already been trusted for. Cormorant declares as much in its capability, but
@@ -1689,6 +1693,10 @@ public class ElectrumServer {
         if(!Config.get().isVerifyTransactions() || Config.get().getServerType() == ServerType.BITCOIN_CORE
                 || serverCapability == null || !serverCapability.supportsMerkleProofs()) {
             return false;
+        }
+
+        if(isVerificationMandatory()) {
+            return true;
         }
 
         ChainTip announced = AppServices.getAnnouncedTip();
@@ -2726,6 +2734,26 @@ public class ElectrumServer {
     }
 
     /**
+     * Sanity checks a tip announced during a session, being the connect time checks above plus the one thing only a session can establish: a chain
+     * does not rewind below a compiled in pin. A server that has announced a tip at or above the last pinned header and then announces one below it
+     * is not a server catching up, it is withdrawing the ground verification stands on, so the announcement is refused rather than acted on.
+     */
+    static String getAnnouncedTipValidationError(BlockHeaderTip tip) {
+        String tipError = getTipValidationError(tip);
+        if(tipError != null) {
+            return tipError;
+        }
+
+        int maxCheckpointHeight = Network.get().getHeaderCheckpoints().getMaxHeight();
+        if(tipReachedCheckpoints && tip.height < maxCheckpointHeight) {
+            return "Announced block header tip at height " + tip.height + " is below the last verified checkpoint at height " + maxCheckpointHeight
+                    + ", which the connected server has already announced a tip above";
+        }
+
+        return null;
+    }
+
+    /**
      * Logs and shows a status warning for an invalid tip. A hostile server can send invalid tips at any rate, so warnings are rate limited,
      * and the status warning is shown at most once per episode of invalid tips (reset on any valid tip).
      */
@@ -2743,17 +2771,20 @@ public class ElectrumServer {
     }
 
     private static void initializeTip(BlockHeaderTip tip) {
-        updateTipReceived();
+        updateTipReceived(tip.height);
         //Public servers are never mid-sync, so seed the staleness clock from the tip timestamp to warn promptly on an already stale server
         if(Config.get().getServerType() == ServerType.PUBLIC_ELECTRUM_SERVER) {
             lastTipReceivedAt = Math.min(lastTipReceivedAt, tip.getBlockHeader().getTime() * 1000);
         }
     }
 
-    static void updateTipReceived() {
+    static void updateTipReceived(int height) {
         lastTipReceivedAt = System.currentTimeMillis();
         staleTipWarned = false;
         invalidTipWarned = false;
+        if(height >= Network.get().getHeaderCheckpoints().getMaxHeight()) {
+            tipReachedCheckpoints = true;
+        }
     }
 
     public static ServerCapability getServerCapability(List<String> serverVersion) {
@@ -2954,6 +2985,8 @@ public class ElectrumServer {
                     if(firstCall) {
                         electrumServer.connect();
 
+                        //What the last server announced says nothing about this one, and is cleared before the thread that dispatches announcements exists
+                        tipReachedCheckpoints = false;
                         reader = new Thread(new ReadRunnable(), "ElectrumServerReadThread");
                         reader.setDaemon(true);
                         reader.setUncaughtExceptionHandler(ConnectionService.this);

--- a/src/main/java/com/sparrowwallet/sparrow/net/SubscriptionService.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/SubscriptionService.java
@@ -22,13 +22,13 @@ public class SubscriptionService {
 
     @JsonRpcMethod("blockchain.headers.subscribe")
     public void newBlockHeaderTip(@JsonRpcParam("header") final BlockHeaderTip header) {
-        String tipError = ElectrumServer.getTipValidationError(header);
+        String tipError = ElectrumServer.getAnnouncedTipValidationError(header);
         if(tipError != null) {
             ElectrumServer.warnInvalidTip(tipError);
             return;
         }
 
-        ElectrumServer.updateTipReceived();
+        ElectrumServer.updateTipReceived(header.height);
         ElectrumServer.updateRetrievedBlockHeaders(header.height, header.getBlockHeader());
         Platform.runLater(() -> EventManager.get().post(new NewBlockEvent(header.height, header.getBlockHeader())));
     }

--- a/src/main/java/com/sparrowwallet/sparrow/net/VerboseTransaction.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/VerboseTransaction.java
@@ -50,6 +50,9 @@ public class VerboseTransaction {
             throw new IllegalStateException("Server returned transaction " + transaction.getTxId() + " for declared txid " + declaredTxid);
         }
 
-        return new BlockTransaction(declaredTxid, getHeight(), getDate(), 0L, transaction, blockhash == null ? null : Sha256Hash.wrap(blockhash));
+        //A block hash records the block a transaction was proven to be in, and nothing here is proven: the server's own is dropped, and only the marker
+        //for a response that could not carry one is passed on, that being a statement about the response rather than about the block
+        boolean incomplete = Sha256Hash.ZERO_HASH.toString().equals(blockhash);
+        return new BlockTransaction(declaredTxid, getHeight(), getDate(), 0L, transaction, incomplete ? Sha256Hash.ZERO_HASH : null);
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -90,6 +90,11 @@ public class HeadersController extends TransactionFormController implements Init
 
     private HeadersForm headersForm;
 
+    //The txid:height last asked about, so that a redraw does not ask again, and the request that asked it
+    private String verificationRequestedPair;
+
+    private ElectrumServer.TransactionVerificationService verificationService;
+
     @FXML
     private IdLabel id;
 
@@ -827,24 +832,35 @@ public class HeadersController extends TransactionFormController implements Init
         locktimeCurrentHeight.setDisable(!locktimeEnabled);
     }
 
-    private void updateBlockchainForm(BlockTransaction blockTransaction, Integer currentHeight) {
+    private void updateBlockchainForm(BlockTransaction reportedTransaction, Integer currentHeight) {
         signaturesForm.setVisible(false);
         blockchainForm.setVisible(true);
         updateEditable(false);
+
+        //Carrying the block it was proven to be in where this session has proved it, so that the form reads the same whichever redraw arrives last:
+        //the wallet's own transaction and the one an input fetch reports are both handed over without what a proof has since established
+        BlockTransaction blockTransaction = ElectrumServer.getProvenTransaction(reportedTransaction);
+
+        //A block hash is recorded only where the transaction was proven to be in that block, so a confirmed height without one is the server's word
+        //alone. Asked of what is shown rather than of the wallets: a height a wallet refused and demoted is fetched from the server again, and the
+        //server's answer is what reaches this form
+        boolean unverified = blockTransaction.getHeight() > 0 && !ElectrumServer.isProven(blockTransaction) && ElectrumServer.isVerifyingTransactions();
+        String unverifiedSuffix = unverified ? " (Unverified)" : "";
+        blockStatus.setTooltip(unverified ? new Tooltip("The server reported this height but has not proven the transaction was included in that block") : null);
 
         if(Sha256Hash.ZERO_HASH.equals(blockTransaction.getBlockHash()) && blockTransaction.getHeight() == 0 && headersForm.getPsbt() == null) {
             //A zero block hash indicates that this blocktransaction is incomplete and the height is likely incorrect if we are not sending a tx
             blockStatus.setText("Unknown");
         } else if(currentHeight == null) {
-            blockStatus.setText(blockTransaction.getHeight() > 0 ? "Confirmed" : "Unconfirmed");
+            blockStatus.setText(blockTransaction.getHeight() > 0 ? "Confirmed" + unverifiedSuffix : "Unconfirmed");
         } else {
             int confirmations = blockTransaction.getHeight() > 0 ? currentHeight - blockTransaction.getHeight() + 1 : 0;
             if(confirmations == 0) {
                 blockStatus.setText("Unconfirmed");
             } else if(confirmations == 1) {
-                blockStatus.setText(confirmations + " Confirmation");
+                blockStatus.setText(confirmations + " Confirmation" + unverifiedSuffix);
             } else {
-                blockStatus.setText(confirmations + " Confirmations");
+                blockStatus.setText(confirmations + " Confirmations" + unverifiedSuffix);
             }
 
             if(confirmations <= BlockTransactionHash.BLOCKS_TO_CONFIRM) {
@@ -894,6 +910,58 @@ public class HeadersController extends TransactionFormController implements Init
         } else {
             signedByField.setVisible(false);
         }
+
+        if(unverified) {
+            verifyBlockTransaction(blockTransaction);
+        }
+    }
+
+    /**
+     * Asks the server to prove the height it reported for a transaction that did not arrive proven, whether or not a wallet holds it: what a wallet
+     * proved is carried on the transaction it holds, and a height fetched from the server again is the server's however familiar the txid. Started
+     * from the form rather than from the fetch so that the transaction is shown while this runs, and shown unverified until it returns a header: a
+     * server that declines the proof leaves the claim standing as its own.
+     * <p>
+     * The pair records what this server has answered, so only an answer records it. Asked while offline, or cut off partway, nothing has been
+     * answered and the next redraw asks again - the capability that decides whether to ask at all is settled at connect and outlives the connection,
+     * so without this an offline redraw would leave the tab reading unverified on a question no server was ever put.
+     */
+    private void verifyBlockTransaction(BlockTransaction blockTransaction) {
+        String pair = blockTransaction.getHashAsString() + ":" + blockTransaction.getHeight();
+        if(pair.equals(verificationRequestedPair) || !AppServices.isConnected()) {
+            return;
+        }
+
+        verificationRequestedPair = pair;
+        ElectrumServer.TransactionVerificationService transactionVerificationService =
+                new ElectrumServer.TransactionVerificationService(blockTransaction.getHash(), blockTransaction.getHeight());
+        verificationService = transactionVerificationService;
+        transactionVerificationService.setOnSucceeded(workerStateEvent -> {
+            BlockHeader provenHeader = transactionVerificationService.getValue();
+            //Asked of the chain as it was: a reorg since drops the request, the proof having reconstructed a header that is no longer at that height
+            if(verificationService == transactionVerificationService && headersForm.getTransaction().getTxId().equals(blockTransaction.getHash())) {
+                //Written only where there is something to write: the transaction captured when this was asked is older than whatever the form has
+                //learned since, and a wallet proving what this request was refused is exactly what it would overwrite. Built from the header the proof
+                //was verified against rather than looked up, so what is shown does not rest on the proof having been remembered
+                if(provenHeader != null) {
+                    headersForm.setBlockTransaction(ElectrumServer.getProvenTransaction(blockTransaction, provenHeader));
+                }
+
+                //Redrawn whatever the answer, since a server turning out not to implement the call turns verification off, and the form would else be
+                //left qualifying a height on grounds that no longer hold
+                BlockTransaction shown = headersForm.getBlockTransaction() == null ? blockTransaction : headersForm.getBlockTransaction();
+                updateBlockchainForm(shown, AppServices.getCurrentBlockHeight());
+            }
+        });
+        transactionVerificationService.setOnFailed(workerStateEvent -> {
+            log.debug("Could not reach the server to verify transaction " + blockTransaction.getHashAsString(), workerStateEvent.getSource().getException());
+            //Only the request still outstanding releases the pair: one a reconnect has already replaced is asking about the same pair, so the pair
+            //cannot tell them apart, and letting the older failure release it would put a third request behind the one in flight
+            if(verificationService == transactionVerificationService) {
+                verificationRequestedPair = null;
+            }
+        });
+        transactionVerificationService.start();
     }
 
     private void initializeSignButton(Wallet signingWallet) {
@@ -1499,6 +1567,9 @@ public class HeadersController extends TransactionFormController implements Init
         if(transactionMempoolService != null) {
             transactionMempoolService.cancel();
         }
+        if(verificationService != null) {
+            verificationService.cancel();
+        }
     }
 
     @Subscribe
@@ -1515,7 +1586,8 @@ public class HeadersController extends TransactionFormController implements Init
         if(event.getTxId().equals(headersForm.getTransaction().getTxId())) {
             if(event.getBlockTransaction() != null && (!Sha256Hash.ZERO_HASH.equals(event.getBlockTransaction().getBlockHash()) || headersForm.getBlockTransaction() == null)) {
                 updateBlockchainForm(event.getBlockTransaction(), AppServices.getCurrentBlockHeight());
-            } else if(headersForm.getPsbt() == null && headersForm.getBlockTransaction() == null) {
+            } else if(headersForm.getPsbt() == null && headersForm.getBlockTransaction() == null && event.getPageStart() == 0) {
+                //Only the first page asks about the transaction itself, so only its silence says the transaction is not on chain
                 updateSignedTransactionForm();
             }
 
@@ -1860,13 +1932,37 @@ public class HeadersController extends TransactionFormController implements Init
         }
     }
 
+    /**
+     * A block above the fork is no longer the block a transaction at that height was proven to be in, so what was proven is dropped and asked again.
+     * Posted on the syncing thread while it holds the sync lock, so nothing is done here beyond hopping to the application thread.
+     */
+    @Subscribe
+    public void chainReorg(ChainReorgEvent event) {
+        Platform.runLater(() -> {
+            BlockTransaction blockTransaction = headersForm.getBlockTransaction();
+            if(blockTransaction != null && blockTransaction.getHeight() > event.getForkHeight()) {
+                BlockTransaction reorganised = new BlockTransaction(blockTransaction.getHash(), blockTransaction.getHeight(), null,
+                        blockTransaction.getFee(), blockTransaction.getTransaction(), null);
+                headersForm.setBlockTransaction(reorganised);
+                //Both dropped, so that the proof is asked again and an answer already on its way is not applied to a chain it was not asked of
+                verificationRequestedPair = null;
+                verificationService = null;
+                updateBlockchainForm(reorganised, AppServices.getCurrentBlockHeight());
+            }
+        });
+    }
+
     @Subscribe
     public void connection(ConnectionEvent event) {
         broadcastProgressBar.setDisable(false);
+        if(headersForm.getBlockTransaction() != null) {
+            updateBlockchainForm(headersForm.getBlockTransaction(), event.getBlockHeight());
+        }
     }
 
     @Subscribe
     public void disconnection(DisconnectionEvent event) {
+        verificationRequestedPair = null;
         broadcastProgressBar.setDisable(true);
         if(broadcastProgressBar.getProgress() < 0) {
             broadcastProgressBar.setProgress(0);

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -560,7 +560,7 @@ public class HeadersController extends TransactionFormController implements Init
                     Optional<ButtonType> optType = AppServices.showWarningDialog("Confirm Sighash None",
                             "A sighash value of none means the signature does not commit to any of the outputs, and can be reused on a transaction with different outputs.\n\nAre you sure?",
                             ButtonType.NO, ButtonType.YES);
-                    if(optType.isPresent() && optType.get() == ButtonType.NO) {
+                    if(optType.isEmpty() || optType.get() != ButtonType.YES) {
                         Platform.runLater(() -> sigHash.getSelectionModel().select(oldValue));
                         return;
                     }

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/TransactionController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/TransactionController.java
@@ -398,7 +398,9 @@ public class TransactionController implements Initializable {
             Platform.runLater(() -> EventManager.get().post(new BlockTransactionFetchedEvent(getTransaction(), walletBlockTx, Collections.emptyMap(), 0, getTransaction().getInputs().size())));
         } else if(AppServices.isConnected() && indexStart < getTransaction().getInputs().size()) {
             Set<Sha256Hash> references = new HashSet<>();
-            if(getPSBT() == null) {
+            //Asked for with the first page alone, since a later page cannot learn anything about it that the first did not, and would replace what has
+            //been proven since with the server's unproven word. A confirmed wallet transaction is not asked for at all, being proven at its height already
+            if(getPSBT() == null && indexStart == 0 && (walletBlockTx == null || walletBlockTx.getHeight() <= 0)) {
                 references.add(getTransaction().getTxId());
             }
 
@@ -411,14 +413,24 @@ public class TransactionController implements Initializable {
             }
 
             if(references.isEmpty()) {
+                //A coinbase transaction the wallet already holds proven: there is no input to fetch and no reason to ask about the transaction itself,
+                //but the form is still waiting to be told what the wallet has
+                transactionsFetched = true;
+                Platform.runLater(() -> EventManager.get().post(new BlockTransactionFetchedEvent(getTransaction(), walletBlockTx, Collections.emptyMap(), indexStart, maxIndex)));
                 return;
             }
 
             ElectrumServer.TransactionReferenceService transactionReferenceService = new ElectrumServer.TransactionReferenceService(references);
             transactionReferenceService.setOnSucceeded(successEvent -> {
-                transactionsFetched = true;
+                //The first page is the one that asks about the transaction itself, so only it settles whether a reconnect need fetch again: a later
+                //page succeeding says nothing about a first page that failed, and would otherwise stand in for it
+                if(indexStart == 0) {
+                    transactionsFetched = true;
+                }
                 Map<Sha256Hash, BlockTransaction> transactionMap = transactionReferenceService.getValue();
-                BlockTransaction thisBlockTx = null;
+                //Only the page that asks about the transaction reports it, since a page that did not ask has nothing of its own to say and would
+                //otherwise answer with what the wallet holds over what the first page was told
+                BlockTransaction thisBlockTx = indexStart == 0 ? walletBlockTx : null;
                 Map<Sha256Hash, BlockTransaction> retrievedInputTransactions = new HashMap<>();
                 for(Sha256Hash txid : transactionMap.keySet()) {
                     BlockTransaction retrievedBlockTx = transactionMap.get(txid);

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsWalletForm.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SettingsWalletForm.java
@@ -197,6 +197,10 @@ public class SettingsWalletForm extends WalletForm {
             if(!Objects.equals(originalKeystore.getExtendedPublicKey(), changedKeystore.getExtendedPublicKey())) {
                 return true;
             }
+
+            if(!Objects.equals(originalKeystore.getSilentPaymentScanAddress(), changedKeystore.getSilentPaymentScanAddress())) {
+                return true;
+            }
         }
 
         return false;

--- a/src/test/java/com/sparrowwallet/sparrow/net/ElectrumServerTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/ElectrumServerTest.java
@@ -206,8 +206,10 @@ public class ElectrumServerTest {
     @Test
     public void doesNotVerifyAgainstAServerBelowTheLastPin() {
         ServerCapability previousCapability = ElectrumServer.serverCapability;
+        ServerType previousServerType = Config.get().getServerType();
         try {
             ElectrumServer.serverCapability = new ServerCapability(false, false, false);
+            Config.get().setServerType(ServerType.ELECTRUM_SERVER);
             int maxCheckpointHeight = Network.MAINNET.getHeaderCheckpoints().getMaxHeight();
             BlockHeader header = Network.MAINNET.getGenesisHeader();
 
@@ -224,7 +226,95 @@ public class ElectrumServerTest {
             ElectrumServer.serverCapability.withMerkleProofs(false);
             assertFalse(ElectrumServer.isVerifyingTransactions());
         } finally {
+            Config.get().setServerType(previousServerType);
             ElectrumServer.serverCapability = previousCapability;
+            AppServices.setAnnouncedTip(null);
+        }
+    }
+
+    /**
+     * The lagging server accommodation is not offered where verification is mandatory. A public server was already above the last pin when it was
+     * accepted at connect, so an announced tip below it is not a server catching up, and letting it stand would hand the tier that must verify a
+     * switch the server itself chooses.
+     */
+    @Test
+    public void verifiesAgainstAMandatoryServerHoweverLowItSaysItIs() {
+        ServerCapability previousCapability = ElectrumServer.serverCapability;
+        ServerType previousServerType = Config.get().getServerType();
+        try {
+            ElectrumServer.serverCapability = new ServerCapability(false, false, false);
+            Config.get().setServerType(ServerType.PUBLIC_ELECTRUM_SERVER);
+            assertTrue(ElectrumServer.isVerificationMandatory());
+
+            AppServices.setAnnouncedTip(new ChainTip(Network.MAINNET.getHeaderCheckpoints().getMaxHeight() - 1, Network.MAINNET.getGenesisHeader()));
+            assertTrue(ElectrumServer.isVerifyingTransactions());
+        } finally {
+            Config.get().setServerType(previousServerType);
+            ElectrumServer.serverCapability = previousCapability;
+            AppServices.setAnnouncedTip(null);
+        }
+    }
+
+    /**
+     * A chain does not rewind below a compiled in pin, so a server that has announced a tip at or above the last pinned header and then announces one
+     * below it is refused. Nothing else binds the announced height to the header it arrives with, and the height is what decides whether the session
+     * verifies at all.
+     */
+    @Test
+    public void rejectsAnAnnouncedTipRegressingBelowTheLastPin() {
+        int maxCheckpointHeight = Network.MAINNET.getHeaderCheckpoints().getMaxHeight();
+        try {
+            ElectrumServer.updateTipReceived(maxCheckpointHeight);
+            assertNotNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight - 1, BLOCK_800000_HEADER_HEX)));
+
+            //The regression that would go unnoticed: a genuine current header paired with a height a couple of thousand blocks back
+            assertNotNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight - 2000, BLOCK_800000_HEADER_HEX)));
+        } finally {
+            ElectrumServer.tipReachedCheckpoints = false;
+        }
+    }
+
+    /**
+     * The path that must keep working: a private server catching up announces tip after tip below the last pin, and crosses it once. Only a tip below
+     * the pin from a server that has already announced one above it is a regression.
+     */
+    @Test
+    public void acceptsAnAnnouncedTipFromAServerStillCatchingUp() {
+        int maxCheckpointHeight = Network.MAINNET.getHeaderCheckpoints().getMaxHeight();
+        try {
+            //Nothing announced yet, as at the first announcement of a session
+            ElectrumServer.tipReachedCheckpoints = false;
+            assertNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight - 2000, BLOCK_800000_HEADER_HEX)));
+
+            ElectrumServer.updateTipReceived(maxCheckpointHeight - 2000);
+            assertNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight - 1999, BLOCK_800000_HEADER_HEX)));
+            assertNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight, BLOCK_800000_HEADER_HEX)));
+
+            //An ordinary reorg above the pin is not a regression
+            ElectrumServer.updateTipReceived(maxCheckpointHeight + 2);
+            assertNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight + 1, BLOCK_800000_HEADER_HEX)));
+        } finally {
+            ElectrumServer.tipReachedCheckpoints = false;
+        }
+    }
+
+    /**
+     * What the previous server announced is not evidence about this one. The announced tip outlives the connection that set it and is only replaced
+     * when the FX thread handles the connection event, several round trips after the reading thread starts dispatching announcements, so a server
+     * still catching up would otherwise have its first headers refused for the height its predecessor reached.
+     */
+    @Test
+    public void acceptsAnAnnouncedTipFromANewServerBelowTheOneBefore() {
+        int maxCheckpointHeight = Network.MAINNET.getHeaderCheckpoints().getMaxHeight();
+        try {
+            ElectrumServer.updateTipReceived(maxCheckpointHeight + 100);
+            AppServices.setAnnouncedTip(new ChainTip(maxCheckpointHeight + 100, Network.MAINNET.getGenesisHeader()));
+
+            //Connecting to a server still catching up, which clears the record where the reading thread is started
+            ElectrumServer.tipReachedCheckpoints = false;
+            assertNull(ElectrumServer.getAnnouncedTipValidationError(tip(maxCheckpointHeight - 2000, BLOCK_800000_HEADER_HEX)));
+        } finally {
+            ElectrumServer.tipReachedCheckpoints = false;
             AppServices.setAnnouncedTip(null);
         }
     }

--- a/src/test/java/com/sparrowwallet/sparrow/net/TransactionProofTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/TransactionProofTest.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -60,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -123,6 +125,7 @@ public class TransactionProofTest {
         ElectrumServer.headerStore = null;
         ElectrumServer.lastReorgForkHeight = Integer.MAX_VALUE;
         ElectrumServer.verifiedHistoricalHeaders.clear();
+        ElectrumServer.provenTransactionHeaders.clear();
         ElectrumServer.clearPreviousServerState();
         ElectrumServer.getSubscribedScriptHashes().clear();
         previousElectrumServerRpc = ElectrumServer.electrumServerRpc;
@@ -155,6 +158,7 @@ public class TransactionProofTest {
         ElectrumServer.headerStore = null;
         ElectrumServer.lastReorgForkHeight = Integer.MAX_VALUE;
         ElectrumServer.verifiedHistoricalHeaders.clear();
+        ElectrumServer.provenTransactionHeaders.clear();
         //Every wallet here derives from the same key, so one test's cached script hash state is the next one's, and the caches are keyed by script hash
         ElectrumServer.clearPreviousServerState();
         ElectrumServer.getSubscribedScriptHashes().clear();
@@ -184,6 +188,137 @@ public class TransactionProofTest {
         assertEquals(chain.get(PROVEN_HEIGHT - 1).getHash(), written.getBlockHash());
         assertEquals(1, server.getProofRequests());
         assertEquals(0, server.getBlockHeaderRequests());
+        assertTrue(listener.isEmpty());
+    }
+
+    /**
+     * The same proof asked for a transaction that reached the transaction tab rather than a wallet, where there is no history to demote: the header it
+     * was proven against is returned for the tab to show the block by, and nothing is reported per wallet.
+     */
+    @Test
+    public void provesATransactionOutsideAWallet() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        server.serveProof(transaction, PROVEN_HEIGHT, 0);
+
+        BlockHeader provenHeader = new ElectrumServer().getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT);
+
+        assertNotNull(provenHeader);
+        assertEquals(chain.get(PROVEN_HEIGHT - 1).getHash(), provenHeader.getHash());
+        assertTrue(listener.isEmpty());
+    }
+
+    /**
+     * The three ways the answer is no, each of which leaves the tab showing the height as the server's word alone: a proof declined, one answered for
+     * a different block than the one asked about, and one whose branch does not reconstruct.
+     */
+    @Test
+    public void doesNotProveATransactionTheServerWillNotSubstantiate() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        ElectrumServer electrumServer = new ElectrumServer();
+
+        //Declined: nothing served for this pair at all
+        assertNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        //Answered for another block, which substantiates nothing about the height asked for
+        TransactionMerkleProof otherBlock = server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        otherBlock.block_height = PROVEN_HEIGHT + 1;
+        assertNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        //Tampered: the branch does not reconstruct the merkle root of the header at that height
+        TransactionMerkleProof tampered = server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        tampered.merkle.set(0, Sha256Hash.ZERO_HASH.toString());
+        assertNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        assertTrue(listener.isEmpty());
+    }
+
+    /**
+     * A proof answered once is answered for the session. A transaction reopened, or open in a second tab, does not put the same question again, which
+     * is what keeps history predating the proofs from costing a round trip every time one of it is looked at.
+     */
+    @Test
+    public void provesATransactionOutsideAWalletOnce() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        ElectrumServer electrumServer = new ElectrumServer();
+
+        assertNotNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+        assertNotNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        assertEquals(1, server.getProofRequests());
+    }
+
+    /**
+     * A proof obtained across a reorg is returned but not remembered: the clear a reorg performs holds the sync lock, and the proof would otherwise be
+     * written behind it and left proven against a header the chain no longer holds. A later proof, with no reorg under it, is remembered as usual.
+     */
+    @Test
+    public void doesNotRememberAProofObtainedAcrossAReorg() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        server.reorgWhileProving();
+        ElectrumServer electrumServer = new ElectrumServer();
+
+        assertNotNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+        assertNotNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+        assertEquals(2, server.getProofRequests());
+
+        //Nothing rewound under this one, so the session remembers it and the third request is not made
+        assertNotNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+        assertEquals(2, server.getProofRequests());
+    }
+
+    /**
+     * What a proof established is carried onto a transaction built without it, which is how a form reads the same whichever of the objects handed
+     * around for one transaction it is redrawn from. A transaction not proven this session is returned as it is.
+     */
+    @Test
+    public void carriesAProofOntoATransactionBuiltWithoutIt() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        BlockTransaction reported = new BlockTransaction(transaction.getTxId(), PROVEN_HEIGHT, new Date(0), 0L, transaction);
+
+        assertSame(reported, ElectrumServer.getProvenTransaction(reported));
+
+        assertNotNull(new ElectrumServer().getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        BlockTransaction proven = ElectrumServer.getProvenTransaction(reported);
+        assertEquals(chain.get(PROVEN_HEIGHT - 1).getHash(), proven.getBlockHash());
+        assertEquals(chain.get(PROVEN_HEIGHT - 1).getTimeAsDate(), proven.getDate());
+        assertEquals(PROVEN_HEIGHT, proven.getHeight());
+    }
+
+    /**
+     * Only what was proven is remembered. A server that would not prove it is not necessarily the server that will be asked next, and caching the
+     * refusal would outlast the connection that earned it.
+     */
+    @Test
+    public void doesNotRememberARefusal() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        server.refuseFirstAttempts(transaction, PROVEN_HEIGHT, 1);
+        ElectrumServer electrumServer = new ElectrumServer();
+
+        assertNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+        assertNotNull(electrumServer.getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        assertEquals(2, server.getProofRequests());
+    }
+
+    /**
+     * A server that does not implement the call is settled for the session rather than answered per transaction. Nothing else would settle it where
+     * the tab is the only caller, and every transaction would then be shown unverified against a server that had not refused anything.
+     */
+    @Test
+    public void disablesVerificationWhereTheServerLacksTheProofCall() throws Exception {
+        Transaction transaction = blockTransactions.getFirst();
+        server.serveProof(transaction, PROVEN_HEIGHT, 0);
+        server.setProofFailure(new UnsupportedMethodException("blockchain.transaction.get_merkle", null));
+
+        assertNull(new ElectrumServer().getProvenHeader(transaction.getTxId(), PROVEN_HEIGHT));
+
+        assertFalse(ElectrumServer.serverCapability.supportsMerkleProofs());
+        assertFalse(ElectrumServer.isVerifyingTransactions());
         assertTrue(listener.isEmpty());
     }
 
@@ -1093,6 +1228,7 @@ public class TransactionProofTest {
         private volatile int proofFailureAfter;
         private volatile int proofFailureUntil = Integer.MAX_VALUE;
         private volatile RuntimeException headersFailure;
+        private volatile boolean reorgWhileProving;
 
         public FakeProofServer(List<BlockHeader> chain) {
             this.chain = List.copyOf(chain);
@@ -1102,6 +1238,10 @@ public class TransactionProofTest {
         @Override
         public Map<String, TransactionMerkleProof> getTransactionMerkleProofs(Transport transport, Wallet wallet, Collection<BlockTransactionHash> references) {
             int request = proofRequests.incrementAndGet();
+            if(reorgWhileProving) {
+                reorgWhileProving = false;
+                ElectrumServer.reorgCount++;
+            }
             proofRequestKeys.add(references.stream().map(FakeProofServer::key).collect(Collectors.toCollection(LinkedHashSet::new)));
             if(proofFailure != null && request > proofFailureAfter && request <= proofFailureUntil) {
                 throw proofFailure;
@@ -1210,6 +1350,13 @@ public class TransactionProofTest {
             proofs.put(transaction.getTxId() + ":" + height, proof);
 
             return proof;
+        }
+
+        /**
+         * Rewinds the header store while the next proof is in flight, which is a reorg landing between a proof being verified and being remembered.
+         */
+        public void reorgWhileProving() {
+            this.reorgWhileProving = true;
         }
 
         public void serveProof(Sha256Hash txid, int height, TransactionMerkleProof proof) {

--- a/src/test/java/com/sparrowwallet/sparrow/net/VerboseTransactionTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/VerboseTransactionTest.java
@@ -1,10 +1,12 @@
 package com.sparrowwallet.sparrow.net;
 
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
 import com.sparrowwallet.drongo.wallet.BlockTransaction;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class VerboseTransactionTest {
@@ -34,6 +36,36 @@ public class VerboseTransactionTest {
         assertEquals(SEGWIT_TXID, blockTransaction.getHashAsString());
         assertEquals(SEGWIT_WTXID, blockTransaction.getTransaction().getWTxId().toString());
         assertNotEquals(blockTransaction.getTransaction().getTxId(), blockTransaction.getTransaction().getWTxId());
+    }
+
+    /**
+     * The server's own block hash is not evidence that the transaction is in that block, and everywhere a block hash is read it is read as the block
+     * the transaction was proven to be in. Dropped here, so the transaction tab can tell a proven height from a reported one.
+     */
+    @Test
+    public void dropsTheServersUnprovenBlockHash() {
+        VerboseTransaction verboseTransaction = verboseTransaction(LEGACY_TXID, LEGACY_HEX);
+        verboseTransaction.blockhash = "00000000000000000002a7c4c1e48d76c5a37902165a270156b7a8d72728a054";
+        verboseTransaction.confirmations = 6;
+
+        BlockTransaction blockTransaction = verboseTransaction.getBlockTransaction();
+
+        assertNull(blockTransaction.getBlockHash());
+    }
+
+    /**
+     * The one block hash that survives says nothing about a block: it marks a response that could not carry a height at all, which the transaction tab
+     * shows as an unknown status rather than as a confirmation.
+     */
+    @Test
+    public void keepsTheMarkerForAnIncompleteResponse() {
+        VerboseTransaction verboseTransaction = verboseTransaction(LEGACY_TXID, LEGACY_HEX);
+        verboseTransaction.blockhash = Sha256Hash.ZERO_HASH.toString();
+
+        BlockTransaction blockTransaction = verboseTransaction.getBlockTransaction();
+
+        assertEquals(Sha256Hash.ZERO_HASH, blockTransaction.getBlockHash());
+        assertEquals(0, blockTransaction.getHeight());
     }
 
     @Test


### PR DESCRIPTION
Brings the fork level with upstream Sparrow and carries the vector artwork, for release as `blake2b.19`.

## Upstream

Six commits, merged with no conflict outside the submodule pointer:

- revert the sighash selection when the SIGHASH_NONE warning is dismissed rather than answered no
- recover the Trezor Safe 7 session when the device retransmits an unacknowledged message
- refuse an announced tip below the last pinned header
- show a height the transaction tab takes from the server as unverified until it is proven
- correct an amount or fee entry that parses as zero when only part of it validates
- compare silent payment scan addresses when considering wallet address changes

`lark` takes the matching two: the Safe 7 retransmit recovery, and skipping packets that are not v1 framed when probing for the protocol version. The capability read this fork adds is untouched and still looks for 29.

`drongo` was already level with upstream.

## Verified

The Trezor suite runs 20 of 20 against a Bitcoin Knots `v29.4.1.knots20260508` regtest node, on a private loopback so nothing else on the machine can answer as the device. Every transaction is judged by the node.

This matters more than usual here. An earlier attempt at this same merge was backed out after the suite reported failures, which were later traced to another emulator holding the port rather than to anything in the merge. Run in isolation, the merge passes clean, so those two commits were never the cause.

Unit suites: drongo 615, Sparrow 396, lark 22, no failures. Sparrow and lark both gain tests from upstream.
