### PR TITLE
Take the opt-in decision from the verified tip where it reaches the announcement

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -768,12 +768,19 @@ public class AppServices {
      * way, and a signature carrying no replay protection is the worse of the two failures to choose.
      */
     private static ChainTip decisionTip() {
-        ChainTip announced = announcedTip;
+        //Read once each: the store can advance between the two reads, and taking the rule below on a verified tip
+        //that no longer matches the announcement it was compared against is the split read ChainTip exists to prevent.
+        return decisionTip(announcedTip, ElectrumServer.getVerifiedTip());
+    }
+
+    /**
+     * The rule itself, taking both tips so it can be exercised without a loaded store.
+     */
+    static ChainTip decisionTip(ChainTip announced, ChainTip verified) {
         if(announced == null) {
             return null;
         }
 
-        ChainTip verified = ElectrumServer.getVerifiedTip();
         return verified != null && verified.height() >= announced.height() ? verified : announced;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -760,6 +760,24 @@ public class AppServices {
     }
 
     /**
+     * The tip the opt-in decision is taken from.
+     *
+     * The announced tip is what a server says. The header store is what has been verified from the pinned anchor, so
+     * where it has reached the announcement its answer cannot be forged and is used instead. Where it is behind, which
+     * is every session until it catches up, the announcement is used as before: declining there would sign the legacy
+     * way, and a signature carrying no replay protection is the worse of the two failures to choose.
+     */
+    private static ChainTip decisionTip() {
+        ChainTip announced = announcedTip;
+        if(announced == null) {
+            return null;
+        }
+
+        ChainTip verified = ElectrumServer.getVerifiedTip();
+        return verified != null && verified.height() >= announced.height() ? verified : announced;
+    }
+
+    /**
      * Whether transactions this wallet creates should opt in to the unified signature hash.
      *
      * The fork carries both the BLAKE2b proof of work and the opt-in signature hash, and both take
@@ -777,7 +795,7 @@ public class AppServices {
     public static boolean isUnifiedSigHashActive() {
         //Read once: ChainTip carries the height and the header together so the decision cannot take the
         //height of one block with the header of another, which two separate reads would allow.
-        ChainTip tip = announcedTip;
+        ChainTip tip = decisionTip();
         return isUnifiedSigHashActive(Network.get(), tip == null ? null : tip.height(), tip == null ? null : tip.header());
     }
 
@@ -1236,7 +1254,7 @@ public class AppServices {
      * wallet also holds a device, since the device is no obstacle until the rules are live.
      */
     public static UnifiedSigHashDecision getUnifiedSigHashDecision(Wallet wallet) {
-        ChainTip tip = announcedTip;
+        ChainTip tip = decisionTip();
         return combinedDecision(chainDecision(Network.get(), tip == null ? null : tip.height(), tip == null ? null : tip.header()), wallet);
     }
 
@@ -1275,7 +1293,7 @@ public class AppServices {
     public static UnifiedSigHashStatus getUnifiedSigHashStatus(Wallet wallet) {
         //One read of the tip for both answers. Reading it again for the caveats would let the headline describe one
         //tip and the caveats another, which is the same class of split reading the ChainTip record exists to prevent.
-        ChainTip tip = announcedTip;
+        ChainTip tip = decisionTip();
         UnifiedSigHashDecision chain = chainDecision(Network.get(), tip == null ? null : tip.height(), tip == null ? null : tip.header());
         UnifiedSigHashDecision decision = combinedDecision(chain, wallet);
 

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -1467,6 +1467,28 @@ public class ElectrumServer {
     }
 
     /**
+     * The tip of the verified header chain, or null where that cannot be answered without loading or fetching.
+     *
+     * Read only on purpose: a caller asking what has been verified must not set a store load or a header download
+     * going, so an absent, superseded or torn store is simply not answered for and the caller falls back.
+     */
+    public static ChainTip getVerifiedTip() {
+        try {
+            HeaderStore store = headerStore;
+            if(store == null || !store.isIntact()) {
+                return null;
+            }
+
+            int height = store.getTipHeight();
+            BlockHeader header = store.getHeader(height);
+            return header == null ? null : new ChainTip(height, header);
+        } catch(IOException e) {
+            log.warn("Could not read the block header store: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * The header store for this network, loaded on first use from a background thread. It is not cleared when the server changes: headers are claims
      * about the chain rather than about the server, and a new server announcing a different tip is handled as an ordinary reorg.
      */

--- a/src/test/java/com/sparrowwallet/sparrow/VerifiedTipDecisionTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/VerifiedTipDecisionTest.java
@@ -1,0 +1,117 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.protocol.BlockHeader;
+import com.sparrowwallet.sparrow.net.ElectrumServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Which tip the opt-in decision is taken from.
+ *
+ * A server's announcement is unauthenticated, so a forged v2 header at or past the activation height could
+ * bring the opt-in forward and every transaction signed under it would fail to verify. The header store is
+ * re-verified from a pinned anchor, so where it has reached the announcement its answer is used instead.
+ *
+ * The fallback is the half worth pinning hardest: where the store is behind, the announcement still decides.
+ * Declining there would sign the legacy way, and a signature carrying no replay protection is the worse of
+ * the two failures, so this must never become more strict than the announcement alone.
+ */
+public class VerifiedTipDecisionTest {
+    private static final int ACTIVATION = AppServices.getUnifiedSigHashActivationHeight(Network.TESTNET4);
+
+    private static final String V2_HEADER_HEX = "000000a01f1e1d1c1b1a191817161514131211100f0e0d0c0b0a0908070605040302010000112233445566778899aabbccddeeff00102030405060708090a0b0c0d0e0f0a8913577ffff00200df0ad0b3a000000efcdab89ffeeddccbbaa998877665544332211005802000003005c000000000000000000000000000000000040d10c008967452301efcdab8967452301efcdab8967452301efcdab8967452301efcdab";
+    private static final String V1_HEADER_HEX = "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299";
+
+    @BeforeEach
+    @AfterEach
+    public void resetNodeHardforkHeight() {
+        AppServices.clearNodeHardforkHeight();
+    }
+
+    private BlockHeader header(String hex) {
+        return new BlockHeader(Utils.hexToBytes(hex), 0);
+    }
+
+    private ChainTip v2(int height) {
+        return new ChainTip(height, header(V2_HEADER_HEX));
+    }
+
+    private ChainTip v1(int height) {
+        return new ChainTip(height, header(V1_HEADER_HEX));
+    }
+
+    @Test
+    public void nothing_heard_from_a_chain_stays_nothing() {
+        Assertions.assertNull(AppServices.decisionTip(null, null));
+        Assertions.assertNull(AppServices.decisionTip(null, v2(ACTIVATION)));
+    }
+
+    @Test
+    public void a_store_level_with_the_announcement_decides() {
+        ChainTip verified = v2(ACTIVATION);
+        Assertions.assertSame(verified, AppServices.decisionTip(v2(ACTIVATION), verified));
+    }
+
+    @Test
+    public void a_store_ahead_of_the_announcement_decides() {
+        ChainTip verified = v2(ACTIVATION + 10);
+        Assertions.assertSame(verified, AppServices.decisionTip(v2(ACTIVATION), verified));
+    }
+
+    @Test
+    public void a_store_behind_the_announcement_does_not_decide() {
+        ChainTip announced = v2(ACTIVATION);
+        Assertions.assertSame(announced, AppServices.decisionTip(announced, v2(ACTIVATION - 1)));
+    }
+
+    @Test
+    public void no_store_leaves_the_announcement_deciding() {
+        ChainTip announced = v2(ACTIVATION);
+        Assertions.assertSame(announced, AppServices.decisionTip(announced, null));
+    }
+
+    /**
+     * The reason this exists: a forged v2 announcement cannot bring the opt-in forward once the store has
+     * verified that height for itself.
+     */
+    @Test
+    public void a_forged_announcement_is_overruled_by_the_verified_chain() {
+        ChainTip forged = v2(ACTIVATION);
+        ChainTip verified = v1(ACTIVATION);
+
+        ChainTip decided = AppServices.decisionTip(forged, verified);
+        UnifiedSigHashDecision decision = AppServices.chainDecision(
+                Network.TESTNET4, decided.height(), decided.header());
+
+        Assertions.assertFalse(decision.isOptedIn());
+        Assertions.assertEquals(UnifiedSigHashDecision.TIP_CONTRADICTS_SCHEDULE, decision);
+
+        //Taken from the announcement alone, as it was before, the same pair opts in
+        Assertions.assertTrue(AppServices.chainDecision(
+                Network.TESTNET4, forged.height(), forged.header()).isOptedIn());
+    }
+
+    /**
+     * A store that has caught up must not make this stricter than the announcement alone: where both agree
+     * the chain is past activation, the answer is still to opt in.
+     */
+    @Test
+    public void a_verified_chain_past_activation_still_opts_in() {
+        ChainTip decided = AppServices.decisionTip(v2(ACTIVATION), v2(ACTIVATION));
+        Assertions.assertTrue(AppServices.chainDecision(
+                Network.TESTNET4, decided.height(), decided.header()).isOptedIn());
+    }
+
+    /**
+     * Asking what has been verified must not throw or start a load where no store is open, because it is
+     * read on the signing decision's path.
+     */
+    @Test
+    public void asking_an_unloaded_store_answers_rather_than_throwing() {
+        Assertions.assertDoesNotThrow(ElectrumServer::getVerifiedTip);
+    }
+}


### PR DESCRIPTION
The opt-in decision read the tip the connected server announced. Nothing authenticates that, so a server announcing a forged v2 header at or past the activation height could bring the opt-in forward on a chain that has not reached it, and every transaction signed under it would fail to verify.

The header store is a different kind of answer: it is re-verified from a pinned anchor on every load, so a forged header cannot enter it. Where it has reached the announced height, its tip is used for the decision instead.

## Why it still falls back

Where the store is behind the announcement, which is every session until it catches up, the announcement is used as before.

Requiring the store outright would look stronger and is the obvious reading of "derive the decision from the verified tip", but it is the wrong trade. A store that has not caught up would decline to opt in, and a signature that does not opt in is the one that can be replayed. That swaps a transaction that fails to confirm for a transaction that is valid on both chains, which is the worse of the two failures.

So the rule is that the verified answer wins where it exists and the announced answer is never given less weight than it already had. This is not less protective than the current behavior at any point in the sync, and it is strictly more protective once the store is level.

## Scope

The accessor is deliberately read only: asking what has been verified must not start a store load or a header download, so an absent, superseded or torn store is simply not answered for and the caller falls back.

`getBlockHeight` and `getBlockHeader` still read the announced tip. They describe what the server has said, which is what their callers display.

Sparrow 396 tests pass.

## Verified

Eight tests pin the rule. Mutated back to the previous behaviour, taking the announcement always, three of them fail, including the one this exists for: a forged v2 announcement at the activation height, overruled by a verified v1 tip at that height, declines; taken from the announcement alone the same pair opts in.

The fallback is pinned in both directions, since the risk in this change is becoming stricter rather than looser: a store behind the announcement, and no store at all, both leave the announcement deciding. A store level with it and past activation still opts in.

Reading an unloaded store answers rather than throwing, which matters because it is read on the signing decision's path.

Sparrow 404 tests, and the Trezor suite 20 of 20 against a Knots regtest node past activation, on a private loopback.
