### PR TITLE
Name this fork's maintainer on the Linux packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,7 @@ jlink {
                 installerName = "shrike"
                 installerOptions.addAll(['--linux-shortcut', '--linux-menu-group', 'Shrike'])
             }
-            installerOptions.addAll(['--resource-dir', layout.buildDirectory.dir('deploy/package').get().asFile.toString(), '--linux-app-category', 'utils', '--linux-app-release', blake2bRelease, '--linux-rpm-license-type', 'ASL 2.0', '--linux-deb-maintainer', 'AcesHigh70 <6564423+AcesHigh70@users.noreply.github.com>'])
+            installerOptions.addAll(['--resource-dir', layout.buildDirectory.dir('deploy/package').get().asFile.toString(), '--linux-app-category', 'utils', '--linux-app-release', blake2bRelease, '--linux-rpm-license-type', 'ASL 2.0', '--linux-deb-maintainer', 'Kyle Santiago <kyle@privkey.io>'])
             imageOptions.addAll(['--icon', 'src/main/deploy/package/linux/Shrike.png', '--resource-dir', 'src/main/deploy/package/linux/'])
             //Set explicitly, as the other two platforms do. Left unset, jpackage attempts every installer
             //type the platform advertises and stops on the one whose tooling is absent, so packaging fails

--- a/src/main/deploy/package/linux-headless/control
+++ b/src/main/deploy/package/linux-headless/control
@@ -1,7 +1,7 @@
 Package: shrikeserver
 Version: ${version}-${release}
 Section: utils
-Maintainer: AcesHigh70 <6564423+AcesHigh70@users.noreply.github.com>
+Maintainer: Kyle Santiago <kyle@privkey.io>
 Priority: optional
 Architecture: ${arch}
 Provides: shrikeserver

--- a/src/main/deploy/package/linux/control
+++ b/src/main/deploy/package/linux/control
@@ -1,7 +1,7 @@
 Package: shrike
 Version: ${version}-${release}
 Section: utils
-Maintainer: AcesHigh70 <6564423+AcesHigh70@users.noreply.github.com>
+Maintainer: Kyle Santiago <kyle@privkey.io>
 Priority: optional
 Architecture: ${arch}
 Provides: shrike


### PR DESCRIPTION
The deb carried `AcesHigh70` as `Maintainer`, inherited with the packaging. That field names whoever maintains the package, and the work moved here when their fork stopped being maintained, so it named someone who cannot answer for these builds. Upstream names its own maintainer in the same field.

Changed in the deb control files for both the desktop and headless packages, and in the `--linux-deb-maintainer` jpackage option that overrides them.

The README credit for their original work on the v2 header, the proof of work, the separate application identity and the packaging is unchanged: that is authorship, which did not move. `Vendor: Unknown` in the rpm specs is jpackage's default and matches upstream, so it is left alone.