### PR TITLE
bump to blake2b.20

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
@@ -20,7 +20,7 @@ public class SparrowWallet {
     public static final String APP_ID = "shrike";
     public static final String APP_NAME = "Shrike";
     public static final String APP_VERSION = "2.5.5";
-    public static final String APP_VERSION_SUFFIX = "-blake2b.19";
+    public static final String APP_VERSION_SUFFIX = "-blake2b.20";
     public static final String APP_HOME_PROPERTY = ApplicationDir.getHomeProperty(APP_NAME);
     public static final String NETWORK_ENV_PROPERTY = "SPARROW_NETWORK";
     public static final String JPACKAGE_APP_PATH = "jpackage.app-path";


### PR DESCRIPTION
Version suffix for the release carrying the verified tip decision, the maintainer correction and the launcher icons.

The About screen and the Debian package release number both read from this, so it moves before the build. `version` in build.gradle stays numeric, as the MSI, deb and rpm packaging requires.