### PR TITLE
Colour the left navigation with the fork's own red

### DIFF
--- a/src/main/resources/com/sparrowwallet/sparrow/app.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.css
@@ -56,12 +56,12 @@
     -fx-pref-height: 50;
     -fx-pref-width: 90;
     -fx-alignment: CENTER;
-    -fx-background-color: derive(#3da0e3, 32%);
+    -fx-background-color: derive(#C4402A, 32%);
     -fx-background-insets: 0 1 0 1,0,0;
 }
 
 .wallet-subtabs > .tab-header-area .tab:selected {
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .wallet-subtabs > .tab-header-area .tab-label {

--- a/src/main/resources/com/sparrowwallet/sparrow/app.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/app.css
@@ -87,7 +87,7 @@
 
 .version-hyperlink, .status-bar .status-label .hyperlink {
     -fx-border-color: transparent;
-    -fx-text-fill: #1e88cf;
+    -fx-text-fill: #C3402A;
 }
 
 .version-hyperlink:visited, .status-bar .status-label .hyperlink {

--- a/src/main/resources/com/sparrowwallet/sparrow/darktheme.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/darktheme.css
@@ -1,10 +1,10 @@
 .root {
-    -fx-accent: #166793;
+    -fx-accent: #8B2D1E;
     -fx-focus-color: -fx-accent;
     -fx-base: #1b1d1f;
     -fx-control-inner-background: derive(-fx-base, 25%);
     -fx-control-inner-background-alt: -fx-control-inner-background ;
-    -fx-default-button: #1e88cf;
+    -fx-default-button: #C3402A;
     -fx-box-border: ladder(-fx-color, black 20%, derive(-fx-color,40%) 30%);
 }
 
@@ -130,20 +130,20 @@ HorizontalHeaderColumn > TableColumnHeader.column-header.table-column{
 }
 
 .root .list-menu {
-    -fx-background-color: #2284bb;
+    -fx-background-color: #B63B27;
 }
 
 .root .list-item {
     -fx-pref-width: 180;
-    -fx-background-color: #2284bb;
+    -fx-background-color: #B63B27;
 }
 
 .root .list-item:hover {
-    -fx-background-color: linear-gradient(to right, #2284bb, derive(#388fc7, 10%));
+    -fx-background-color: linear-gradient(to right, #B63B27, derive(#D2452D, 10%));
 }
 
 .root .list-item:selected {
-    -fx-background-color: linear-gradient(to right, #2284bb, derive(#1479bb, -10%));
+    -fx-background-color: linear-gradient(to right, #B63B27, derive(#AA3825, -10%));
 }
 
 .root .list-item:disabled {
@@ -166,11 +166,11 @@ HorizontalHeaderColumn > TableColumnHeader.column-header.table-column{
 }
 
 .root .wallet-subtabs > .tab-header-area > .headers-region > .tab {
-    -fx-background-color: derive(#2284bb, 32%);
+    -fx-background-color: derive(#B63B27, 32%);
 }
 
 .root .wallet-subtabs > .tab-header-area > .headers-region > .tab:selected {
-    -fx-background-color: #2284bb;
+    -fx-background-color: #B63B27;
 }
 
 #inputsPie .default-color0.chart-pie {
@@ -302,7 +302,7 @@ HorizontalHeaderColumn > TableColumnHeader.column-header.table-column{
 }
 
 .root .placeholder .hyperlink {
-    -fx-text-fill: derive(#1e88cf, 20%);
+    -fx-text-fill: derive(#C3402A, 20%);
 }
 
 .root .box-overlay {
@@ -339,11 +339,11 @@ HorizontalHeaderColumn > TableColumnHeader.column-header.table-column{
 }
 
 .root .hyperlink {
-    -fx-text-fill: #229df5;
+    -fx-text-fill: #D65641;
 }
 
 .root .hyperlink:visited {
-    -fx-text-fill: #229df5;
+    -fx-text-fill: #D65641;
 }
 
 #grid .spreadsheet-cell.selection {

--- a/src/main/resources/com/sparrowwallet/sparrow/general.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/general.css
@@ -110,11 +110,11 @@
 .hyperlink {
     -fx-padding: 0;
     -fx-border-width: 0;
-    -fx-fill: #1e88cf;
+    -fx-fill: #C3402A;
 }
 
 .hyperlink:visited {
-    -fx-text-fill: #1e88cf;
+    -fx-text-fill: #C3402A;
     -fx-underline: false;
 }
 
@@ -138,11 +138,11 @@
 }
 
 .copyable-text-field .copy-button:hover > .graphic {
-    -fx-background-color: #0184bc;
+    -fx-background-color: #9C3321;
 }
 
 .copyable-text-field .copy-button:pressed > .graphic {
-    -fx-background-color: #116a8d;
+    -fx-background-color: #822A1C;
 }
 
 .combo-text-field .combo-button {
@@ -157,11 +157,11 @@
 }
 
 .combo-text-field .combo-button:hover > .graphic {
-    -fx-background-color: #0184bc;
+    -fx-background-color: #9C3321;
 }
 
 .combo-text-field .combo-button:pressed > .graphic {
-    -fx-background-color: #116a8d;
+    -fx-background-color: #822A1C;
 }
 
 .view-password-text-field .view-password-button > .graphic {
@@ -179,11 +179,11 @@
 }
 
 .view-password-text-field .view-password-button:hover > .graphic, .view-password-text-field .hide-password-button:hover > .graphic {
-    -fx-background-color: #0184bc;
+    -fx-background-color: #9C3321;
 }
 
 .view-password-text-field .view-password-button:pressed > .graphic, .view-password-text-field .hide-password-button:pressed > .graphic {
-    -fx-background-color: #116a8d;
+    -fx-background-color: #822A1C;
 }
 
 .readonly.text-input {
@@ -248,11 +248,11 @@
 }
 
 .icon-button .glyph-font {
-    -fx-text-fill: #1e88cf;
+    -fx-text-fill: #C3402A;
 }
 
 .icon-button:hover .glyph-font {
-    -fx-text-fill: #259cf5;
+    -fx-text-fill: #D75843;
 }
 
 .number-field {
@@ -371,4 +371,24 @@ CellView > .text-input.text-field {
 
 .chunk-addresses .tree-table-view .tree-table-row-cell:selected .address-chunk.alternate {
     -fx-fill: derive(-fx-selection-bar-text, 50%);
+}
+
+/* ControlsFX hardcodes a blue for the switched-on state in its own toggleswitch.css, so it is the one
+   control colour the theme cannot reach. Overridden here to the fork's red. The server type switches in
+   welcome.css and settings.css name their own colour with more specificity and are left alone: those say
+   which kind of server is connected, which is not a chrome colour. */
+.toggle-switch:selected .thumb-area {
+    -fx-background-color:
+            linear-gradient(to bottom, derive(-fx-text-box-border, -20%), derive(-fx-text-box-border, -30%)),
+            linear-gradient(to bottom, derive(#AF3925, 30%), #AF3925);
+    -fx-background-insets: 0, 1;
+}
+
+.toggle-switch:selected:focused .thumb-area {
+    -fx-background-color:
+            -fx-focus-color,
+            linear-gradient(to bottom, derive(-fx-text-box-border, -20%), derive(-fx-text-box-border, -30%)),
+            -fx-faint-focus-color,
+            linear-gradient(to bottom, derive(#AF3925, 30%), #AF3925);
+    -fx-background-insets: -0.2, 0, -1.4, 1;
 }

--- a/src/main/resources/com/sparrowwallet/sparrow/keystoreimport/keystoreimport.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/keystoreimport/keystoreimport.css
@@ -4,13 +4,13 @@
 
 .list-menu {
     -fx-pref-width: 160;
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .list-item {
     -fx-pref-width: 160;
     -fx-padding: 0 20 0 20;
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .list-item * {
@@ -18,11 +18,11 @@
 }
 
 .list-item:hover {
-    -fx-background-color: #4aa7e5;
+    -fx-background-color: #D0442D;
 }
 
 .list-item:selected {
-    -fx-background-color: #1e88cf;
+    -fx-background-color: #9A3221;
 }
 
 #importPane {

--- a/src/main/resources/com/sparrowwallet/sparrow/settings/settings.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/settings/settings.css
@@ -4,13 +4,13 @@
 
 .list-menu {
     -fx-pref-width: 160;
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .list-item {
     -fx-pref-width: 160;
     -fx-padding: 0 20 0 20;
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .list-item * {
@@ -18,11 +18,11 @@
 }
 
 .list-item:hover {
-    -fx-background-color: #4aa7e5;
+    -fx-background-color: #D0442D;
 }
 
 .list-item:selected {
-    -fx-background-color: #1e88cf;
+    -fx-background-color: #9A3221;
 }
 
 #settingsPane {

--- a/src/main/resources/com/sparrowwallet/sparrow/transaction/headers.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/transaction/headers.css
@@ -92,11 +92,11 @@
 }
 
 #transactionDiagramLabel .button .glyph-font {
-    -fx-text-fill: #0184bc;
+    -fx-text-fill: #9C3321;
 }
 
 #transactionDiagramLabel .button:hover .glyph-font {
-    -fx-text-fill: #259cf5;
+    -fx-text-fill: #D75843;
 }
 
 .details-lower .fieldset {

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/send.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/send.css
@@ -50,11 +50,11 @@
 }
 
 .chart-line-symbol {
-    -fx-background-color: rgba(30, 136, 207, 0);
+    -fx-background-color: rgba(195, 64, 42, 0);
 }
 
 .chart-line-symbol.selected {
-    -fx-background-color: rgba(30, 136, 207, 0.6);
+    -fx-background-color: rgba(195, 64, 42, 0.6);
 }
 
 .inactive {

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/transactions.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/transactions.css
@@ -15,5 +15,5 @@
 }
 
 .chart-line-symbol.selected {
-    -fx-background-color: rgba(30, 136, 207, 0.6);
+    -fx-background-color: rgba(195, 64, 42, 0.6);
 }

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/utxos.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/utxos.css
@@ -11,7 +11,7 @@
 }
 
 .chart-bar.selected {
-    -fx-bar-fill: rgba(30, 136, 207, 0.6);
+    -fx-bar-fill: rgba(195, 64, 42, 0.6);
 }
 
 .freeze-dust-utxo {

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/wallet.css
@@ -1,11 +1,11 @@
 .list-menu {
     -fx-pref-width: 180;
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .list-item {
     -fx-pref-width: 180;
-    -fx-background-color: #3da0e3;
+    -fx-background-color: #C4402A;
 }
 
 .list-item * {
@@ -13,11 +13,11 @@
 }
 
 .list-item:hover {
-    -fx-background-color: linear-gradient(to right, #3da0e3, derive(#4aa7e5, 10%));
+    -fx-background-color: linear-gradient(to right, #C4402A, derive(#D0442D, 10%));
 }
 
 .list-item:selected {
-    -fx-background-color: linear-gradient(to right, #3da0e3, derive(#1e88cf, -10%));
+    -fx-background-color: linear-gradient(to right, #C4402A, derive(#9A3221, -10%));
 }
 
 .list-item:disabled {


### PR DESCRIPTION
The wallet sidebar, the settings and keystore import menus, and the wallet tab strip were upstream's blue. It is the largest block of colour in the window, and it still read as Sparrow. This takes the site's red, so the application icon, the browser tab and the wallet agree.

## What is red

Enumerated rather than hunted: every colour in every stylesheet, in both hex and `rgb()` notation, mapped to its enclosing selector and then classified.

- The left navigation: wallet sidebar, settings menu, keystore import menu, wallet tab strip
- `-fx-accent` and `-fx-default-button`, which is what colours the New Wallet and Open Wallet links on the empty pane
- Icon buttons and their hover state, which is the CSV and transaction toolbar
- The transaction diagram button
- Copy, combo and password reveal buttons, hover and pressed
- Hyperlinks, in general, dark theme, placeholder and status bar
- Selected point and bar in the transaction, fee and UTXO charts
- The switches, overridden from ControlsFX's own stylesheet

Every red is derived at the **same lightness** as the blue it replaces, so contrast against text and background is carried over rather than guessed.

## What stays blue, on purpose

Thirty eight colours, all of which carry meaning rather than style:

| | why |
|---|---|
| `#txhex`, `.tx-pane` field colours | categorical palette for reading a serialized transaction |
| chart legends, pie slices, `.vsizeChart` | categorical and continuous series |
| `.block-mainnet`, `.block-testnet`, `.block-regtest` | network indicators |
| `.private-electrum` | one of the green, blue and yellow server type set |
| `.script-opcode` and the `#txhex` syntax colours | syntax highlighting |
| `.segment8 .progress-bar` | one of a numbered series |

A red categorical palette cannot separate eight series, and a red server type indicator would collide with the error colour.

## Verified

Three things defeated a first pass that only looked at hex literals in the obvious files, and each is now checked rather than assumed:

- **The dark theme redefines the sidebar** at higher specificity, so the first change applied to nothing in the theme this wallet ships with.
- **Selection colours are `rgba()`**, invisible to a hex sweep. The UTXO chart bar was one of them.
- **The switches come from ControlsFX's own stylesheet**, which no theme colour reaches. The override uses the same selector, so load order decides it, not specificity. Rendered a switched-on toggle and counted pixels: 262 red, 0 blue.

Sparrow 404 tests, and the welcome dialog driven end to end, 30 checks.
