### PR TITLE
Point the app at this project rather than Sparrow's

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AboutController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AboutController.java
@@ -23,7 +23,4 @@ public class AboutController {
         stage.close();
     }
 
-    public void openDonate(ActionEvent event) {
-        AppServices.get().getApplication().getHostServices().showDocument("https://sparrowwallet.com/donate");
-    }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -529,7 +529,7 @@ public class AppController implements Initializable {
     }
 
     public void showDocumentation(ActionEvent event) {
-        AppServices.get().getApplication().getHostServices().showDocument("https://sparrowwallet.com/docs");
+        AppServices.get().getApplication().getHostServices().showDocument("https://shrikewallet.com/docs/");
     }
 
     public void showLogFile(ActionEvent event) throws IOException {
@@ -542,17 +542,17 @@ public class AppController implements Initializable {
     }
 
     public void openSupport(ActionEvent event) {
-        AppServices.get().getApplication().getHostServices().showDocument("https://sparrowwallet.com/opensupport");
+        AppServices.get().getApplication().getHostServices().showDocument("https://github.com/privkeyio/shrike/issues");
     }
 
     public void submitBugReport(ActionEvent event) {
         ButtonType supportType = new ButtonType("Get Support", ButtonBar.ButtonData.LEFT);
         ButtonType bugType = new ButtonType("Submit Bug Report", ButtonBar.ButtonData.YES);
-        Optional<ButtonType> optResponse = showWarningDialog("Submit Bug Report", "Please note that this facility is for bug reports and feature requests only. There is a community of Sparrow users who can assist with support requests.", supportType, bugType);
+        Optional<ButtonType> optResponse = showWarningDialog("Submit Bug Report", "Please note that this facility is for bug reports and feature requests only. Support questions belong in the issue tracker as well.", supportType, bugType);
 
         if(optResponse.isPresent()) {
             if(optResponse.get() == bugType) {
-                AppServices.get().getApplication().getHostServices().showDocument("https://sparrowwallet.com/submitbugreport");
+                AppServices.get().getApplication().getHostServices().showDocument("https://github.com/privkeyio/shrike/issues/new");
             } else {
                 openSupport(event);
             }

--- a/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/settings/ServerSettingsController.java
@@ -705,7 +705,7 @@ public class ServerSettingsController extends SettingsDetailController {
         } else if(exception instanceof ProxyServerException) {
             reason += ". Check if the proxy server is running.";
         } else if(reason != null && (reason.contains("Check if Bitcoin Knots is running") || reason.contains("Could not connect to Bitcoin Knots RPC"))) {
-            reason += "\n\nSee https://sparrowwallet.com/docs/connect-node.html";
+            reason += "\n\nSee https://shrikewallet.com/docs/connect-node.html";
         } else if(reason != null && (reason.startsWith("Cannot connect to hidden service"))) {
             reason += " on the server. Check that the onion address and port are correct, and that both Tor and the Electrum server are running on the node. Usually SSL is not enabled, and the port is 50001.";
         } else if(reason != null && (reason.startsWith("Cannot find Bitcoin Knots cookie file at"))) {

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/settings/ServerTestDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/settings/ServerTestDialog.java
@@ -207,7 +207,7 @@ public class ServerTestDialog extends DialogWindow {
         } else if(exception instanceof ProxyServerException) {
             reason += ". Check if the proxy server is running.";
         } else if(reason != null && reason.contains("Check if Bitcoin Knots is running")) {
-            reason += "\n\nSee https://sparrowwallet.com/docs/connect-node.html";
+            reason += "\n\nSee https://shrikewallet.com/docs/connect-node.html";
         }
 
         testStatus.setText("Failed");

--- a/src/main/resources/com/sparrowwallet/sparrow/about.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/about.fxml
@@ -19,8 +19,8 @@
         <VBox spacing="10" styleClass="content-area">
             <Label text="Shrike is a Bitcoin wallet with the goal of providing greater transparency and usability on the path to full financial self-sovereignty. It attempts to provide all of the detail about your wallet setup, transactions and UTXOs so that you can transact with a full understanding of your money." wrapText="true" />
             <Label text="Shrike can operate in both an online and offline mode. In the online mode it connects to a Bitcoin Knots node or Electrum server to display transaction history. In the offline mode it is useful as a transaction editor and as an airgapped multisig coordinator." wrapText="true" />
-            <Label text="While it's possible to connect to a public Electrum server, connecting Shrike to your Bitcoin Knots node ensures your privacy, while connecting Shrike to your private Electrum server ensures wallets load quicker, you have access to a full blockchain explorer, and your public keys are always encrypted on disk." wrapText="true" />
-            <HBox><Label text="Shrike is a fork of Sparrow. If you find it useful, consider donating to Sparrow at "/><Hyperlink text="https://sparrowwallet.com/donate" onAction="#openDonate"/></HBox>
+            <Label text="Connecting Shrike to your own Bitcoin Knots node ensures your privacy, while connecting it to your own Electrum server indexing that node ensures wallets load quicker, you have access to a full blockchain explorer, and your public keys are always encrypted on disk. No public server is offered, because none of them follow this fork." wrapText="true" />
+            <Label text="Shrike is a fork of Sparrow and inherits its work under the Apache 2.0 license. It is not a Sparrow release, and is neither affiliated with nor supported by the Sparrow project." wrapText="true" />
         </VBox>
         <HBox styleClass="button-area" alignment="BOTTOM_RIGHT" VBox.vgrow="SOMETIMES">
             <Button text="Close" onAction="#close" />


### PR DESCRIPTION
Every link the wallet could open went to `sparrowwallet.com`. That is a separate project, and none of those pages describe this build, so anyone following one was sent somewhere that cannot answer for it.

| where | went to | now goes to |
|---|---|---|
| Help, Documentation | `sparrowwallet.com/docs` | `shrikewallet.com/docs/` |
| Help, Support | `sparrowwallet.com/opensupport` | this project's issue tracker |
| Submit bug report | `sparrowwallet.com/submitbugreport` | this project's issue tracker |
| Server settings, connection help | `sparrowwallet.com/docs/connect-node.html` | `shrikewallet.com/docs/connect-node.html` |
| Terminal server test, same help | as above | as above |
| About | "consider donating to Sparrow", linked | removed |

All three destinations were checked to exist rather than assumed.

The bug report dialog also offered "a community of Sparrow users who can assist with support requests". There is no such community for this fork, so it now points at the issue tracker for both.

## About

The donation request is gone. The credit that replaces it says what the relationship actually is: the work is inherited under the Apache 2.0 license, this is not a Sparrow release, and it is neither affiliated with nor supported by them. That matches the wording the releases already carry.

While there, About still told users they could connect to a public Electrum server. This fork removed those, so the sentence described something the wallet no longer offers.

## Verified

Swept every external URL the app can open, not just the sparrowwallet ones. What remains is this project's own site and issue tracker, `mempool.guide`, exchange rate APIs, PayNym, and upstream code references inside comments. No link to Sparrow remains anywhere in `src/main`.

The About pane is loaded and rendered rather than read: a removed handler still referenced from FXML throws only at load time, which no unit test reaches. It loads with zero hyperlinks, no mention of `sparrowwallet.com`, no donation ask, no public server claim, and the Sparrow credit present.

404 tests pass.
