### PR TITLE
Say which fork is meant in About

### DIFF
--- a/src/main/resources/com/sparrowwallet/sparrow/about.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/about.fxml
@@ -19,8 +19,8 @@
         <VBox spacing="10" styleClass="content-area">
             <Label text="Shrike is a Bitcoin wallet with the goal of providing greater transparency and usability on the path to full financial self-sovereignty. It attempts to provide all of the detail about your wallet setup, transactions and UTXOs so that you can transact with a full understanding of your money." wrapText="true" />
             <Label text="Shrike can operate in both an online and offline mode. In the online mode it connects to a Bitcoin Knots node or Electrum server to display transaction history. In the offline mode it is useful as a transaction editor and as an airgapped multisig coordinator." wrapText="true" />
-            <Label text="Connecting Shrike to your own Bitcoin Knots node ensures your privacy, while connecting it to your own Electrum server indexing that node ensures wallets load quicker, you have access to a full blockchain explorer, and your public keys are always encrypted on disk. No public server is offered, because none of them follow this fork." wrapText="true" />
-            <Label text="Shrike is a fork of Sparrow and inherits its work under the Apache 2.0 license. It is not a Sparrow release, and is neither affiliated with nor supported by the Sparrow project." wrapText="true" />
+            <Label text="Connecting Shrike to your own Bitcoin Knots node ensures your privacy, while connecting it to your own Electrum server indexing that node ensures wallets load quicker, you have access to a full blockchain explorer, and your public keys are always encrypted on disk. No public server is offered, because none of them have adopted the upgrade." wrapText="true" />
+            <Label text="Shrike builds on Sparrow, whose work it inherits under the Apache 2.0 license. It is not a Sparrow release, and is neither affiliated with nor supported by the Sparrow project." wrapText="true" />
         </VBox>
         <HBox styleClass="button-area" alignment="BOTTOM_RIGHT" VBox.vgrow="SOMETIMES">
             <Button text="Close" onAction="#close" />


### PR DESCRIPTION
About used the word *fork* twice in adjacent lines, meaning something different each time:

- "No public server is offered, because none of them follow this fork" meant the chain upgrade
- "Shrike is a fork of Sparrow" meant the wallet

In a wallet whose entire subject is a hardfork, neither reads unambiguously, and the two together invite the reader to assume one sense for both.

The first now says the servers **have not adopted the upgrade**. The second says Shrike **builds on Sparrow**. The credit and the statement of non-affiliation are unchanged in substance, and the word no longer appears in About at all.

The same ambiguity was fixed on the site in six places where a bare "this fork" could have meant either. Uses that plainly mean the hardfork, such as the services that adopted it and the pre-fork rules, are left alone.

Verified by loading and rendering the About pane rather than reading it: it loads with the credit present, no hyperlinks, no mention of sparrowwallet.com, no donation ask, and no public server claim. 404 tests pass.