### PR TITLE
Give this wallet's own name where it identifies itself

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -2903,12 +2903,12 @@ public class AppController implements Initializable {
                 }
 
                 Notifications notificationBuilder = Notifications.create()
-                        .title("Sparrow - " + walletName)
+                        .title(SparrowWallet.APP_NAME + " - " + walletName)
                         .text(text)
                         .graphic(new DialogImage(DialogImage.Type.SPARROW))
                         .hideAfter(Duration.seconds(15))
                         .position(Pos.TOP_RIGHT)
-                        .threshold(5, Notifications.create().title("Sparrow").text("Multiple new wallet transactions").graphic(new DialogImage(DialogImage.Type.SPARROW)))
+                        .threshold(5, Notifications.create().title(SparrowWallet.APP_NAME).text("Multiple new wallet transactions").graphic(new DialogImage(DialogImage.Type.SPARROW)))
                         .onAction(e -> selectTab(event.getWallet()));
 
                 //If controlsfx can't find our window, we must set the window ourselves (unfortunately notification is then shown within this window)

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -17,6 +17,7 @@ import com.sparrowwallet.drongo.silentpayments.SilentPaymentScanMatch;
 import com.sparrowwallet.drongo.silentpayments.SilentPaymentUtils;
 import com.sparrowwallet.drongo.wallet.*;
 import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.SparrowWallet;
 import com.sparrowwallet.sparrow.BlockSummary;
 import com.sparrowwallet.sparrow.ChainTip;
 import com.sparrowwallet.sparrow.EventManager;
@@ -272,7 +273,7 @@ public class ElectrumServer {
     }
 
     public List<String> getServerVersion() throws ServerException {
-        return electrumServerRpc.getServerVersion(getTransport(), "Sparrow", SUPPORTED_VERSIONS);
+        return electrumServerRpc.getServerVersion(getTransport(), SparrowWallet.APP_NAME, SUPPORTED_VERSIONS);
     }
 
     public ServerFeatures getServerFeatures() throws ServerException {


### PR DESCRIPTION
Two places where the wallet still called itself Sparrow, both visible outside the process.

**Desktop notifications** were titled `Sparrow - <wallet>`, and `Sparrow` for the grouped one. That is the notification a user sees on their desktop when a transaction arrives.

**The Electrum handshake** sent `Sparrow` as the client name, so a server's logs and its refusals name a wallet this is not. That is not hypothetical: a server that declines this client reports the refusal against `Sparrow`, which is what the report in issue #22 shows.

Both now take `SparrowWallet.APP_NAME`, so they follow the constant rather than needing an edit wherever the name turns up next.

## What is deliberately unchanged

`io/Sparrow.java` keeps returning `Sparrow` from `getName()`. That names the Sparrow **wallet file format** for import and export, not this application. Renaming it would mislabel the format and confuse the importer that reads it.

The `com.sparrowwallet` package names, the `SparrowWallet` class, and the `SPARROW_NETWORK` environment variable are also untouched: they are upstream's identifiers, they are not shown to anyone, and renaming them would fight every merge for no visible gain.

404 tests pass.
