### PR TITLE
Read the Electrum protocol version, and the header form, that this chain's servers actually use

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/net/BlockHeaders.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/BlockHeaders.java
@@ -1,6 +1,8 @@
 package com.sparrowwallet.sparrow.net;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
 import com.sparrowwallet.drongo.protocol.ProtocolException;
@@ -21,6 +23,43 @@ public class BlockHeaders {
     public int count;
     public String hex;
     public int max;
+
+    /**
+     * Protocol 1.6 changed this field from concatenated hex to a list with one entry per header, and a server answers in whichever form the
+     * negotiated version calls for. Raising the version this client asks for therefore changes the form it is sent by any server capping between
+     * the old maximum and the new one, so reading only the older form would break those servers on every chain, fork or not.
+     *
+     * A list is joined back into the concatenated form, which is what the rest of this class reads. Nothing is lost: the run is walked by each
+     * header's own length either way, and a list entry that is not one whole header is refused here rather than being concatenated into a run that
+     * happens to add up.
+     */
+    @JsonSetter("hex")
+    public void setHex(JsonNode value) {
+        if(value == null || value.isNull()) {
+            hex = null;
+        } else if(value.isTextual()) {
+            hex = value.asText();
+        } else if(value.isArray()) {
+            StringBuilder joined = new StringBuilder();
+            for(JsonNode element : value) {
+                if(!element.isTextual() || new BlockHeaders(element.asText()).getHeaders(1) == null) {
+                    hex = null;
+                    return;
+                }
+                joined.append(element.asText());
+            }
+            hex = joined.toString();
+        } else {
+            hex = null;
+        }
+    }
+
+    public BlockHeaders() {
+    }
+
+    private BlockHeaders(String hex) {
+        this.hex = hex;
+    }
 
     /**
      * The headers this response carries, or null where its hex does not split into exactly the given number of consecutive headers. A header is 80 or

--- a/src/main/java/com/sparrowwallet/sparrow/net/BlockHeaders.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/BlockHeaders.java
@@ -5,13 +5,15 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
+import com.sparrowwallet.drongo.protocol.HeaderChainState;
 import com.sparrowwallet.drongo.protocol.ProtocolException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The blockchain.block.headers response: a run of consecutive block headers as concatenated hex, with the maximum number of headers the server will return.
+ * The blockchain.block.headers response: a run of consecutive block headers, with the maximum number of headers the server will return. The run
+ * arrives as concatenated hex below protocol 1.6 and as a list of one hex string per header at 1.6 and above, never both.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BlockHeaders {
@@ -25,33 +27,34 @@ public class BlockHeaders {
     public int max;
 
     /**
-     * Protocol 1.6 changed this field from concatenated hex to a list with one entry per header, and a server answers in whichever form the
-     * negotiated version calls for. Raising the version this client asks for therefore changes the form it is sent by any server capping between
-     * the old maximum and the new one, so reading only the older form would break those servers on every chain, fork or not.
+     * Protocol 1.6 moved the run out of {@code hex} and into a field of its own, one hex string per header, and a server answers in whichever form
+     * the negotiated version calls for. Raising the version this client asks for therefore changes the form it is sent by any server capping between
+     * the old maximum and the new one, so reading only the older field would break those servers on every chain, fork or not.
      *
-     * A list is joined back into the concatenated form, which is what the rest of this class reads. Nothing is lost: the run is walked by each
-     * header's own length either way, and a list entry that is not one whole header is refused here rather than being concatenated into a run that
-     * happens to add up.
+     * The list is joined back into the concatenated form, which is what the rest of this class, and every caller that reads {@code hex}, already
+     * expects. Nothing is lost: the run is walked by each header's own length either way, and an entry that is not one whole header is refused here
+     * rather than concatenated into a run that happens to add up.
      */
-    @JsonSetter("hex")
-    public void setHex(JsonNode value) {
-        if(value == null || value.isNull()) {
-            hex = null;
-        } else if(value.isTextual()) {
-            hex = value.asText();
-        } else if(value.isArray()) {
-            StringBuilder joined = new StringBuilder();
-            for(JsonNode element : value) {
-                if(!element.isTextual() || new BlockHeaders(element.asText()).getHeaders(1) == null) {
-                    hex = null;
-                    return;
-                }
-                joined.append(element.asText());
-            }
-            hex = joined.toString();
-        } else {
-            hex = null;
+    @JsonSetter("headers")
+    public void setHeaders(JsonNode value) {
+        if(value == null || !value.isArray()) {
+            return;
         }
+
+        StringBuilder joined = new StringBuilder();
+        for(JsonNode element : value) {
+            if(!element.isTextual() || new BlockHeaders(element.asText()).getHeaders(1) == null) {
+                hex = null;
+                return;
+            }
+            joined.append(element.asText());
+            //A server cannot make the join outgrow the largest run this call can legitimately return, whatever it puts in the list
+            if(joined.length() > 2L * HeaderChainState.RETARGET_INTERVAL * BlockHeader.V2_LENGTH) {
+                hex = null;
+                return;
+            }
+        }
+        hex = joined.toString();
     }
 
     public BlockHeaders() {

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -56,7 +56,15 @@ import java.util.stream.Stream;
 public class ElectrumServer {
     private static final Logger log = LoggerFactory.getLogger(ElectrumServer.class);
 
-    static final String[] SUPPORTED_VERSIONS = new String[]{"1.3", "1.4.2"};
+    /**
+     * The range this client negotiates. The maximum is 1.8 because a server on a chain with v2 headers refuses to negotiate below it: a client that
+     * assumes an eighty byte header computes the wrong hash for every block past the activation and fails to link the chain, which reads as a sync
+     * problem rather than as the incompatibility it is, so the server declines rather than serving headers it would be misread.
+     *
+     * Asking for 1.8 also changes the form of a blockchain.block.headers response from any server capping between the old maximum and this one,
+     * which BlockHeaders reads either way.
+     */
+    static final String[] SUPPORTED_VERSIONS = new String[]{"1.3", "1.8"};
 
     private static final Version ELECTRS_MIN_BATCHING_VERSION = new Version("0.9.0");
 

--- a/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/ElectrumServer.java
@@ -57,12 +57,14 @@ public class ElectrumServer {
     private static final Logger log = LoggerFactory.getLogger(ElectrumServer.class);
 
     /**
-     * The range this client negotiates. The maximum is 1.8 because a server on a chain with v2 headers refuses to negotiate below it: a client that
-     * assumes an eighty byte header computes the wrong hash for every block past the activation and fails to link the chain, which reads as a sync
-     * problem rather than as the incompatibility it is, so the server declines rather than serving headers it would be misread.
+     * The range this client negotiates, a minimum and a maximum, so every server still settles on the highest version it supports within it.
      *
-     * Asking for 1.8 also changes the form of a blockchain.block.headers response from any server capping between the old maximum and this one,
-     * which BlockHeaders reads either way.
+     * The maximum is 1.8 because the electrs build that indexes this chain refuses to negotiate below it. A client that assumes an eighty byte header
+     * computes the wrong hash for every block past the activation and fails to link the chain, which reads as a sync problem rather than as the
+     * incompatibility it is, so that server declines rather than serving headers it expects to be misread.
+     *
+     * Reaching past 1.6 on the way there is not incidental. Fulcrum caps at 1.6 and so now settles there rather than at 1.4.2, and 1.6 is where a
+     * blockchain.block.headers response stops being one concatenated string and becomes a list, which is why BlockHeaders has to read both.
      */
     static final String[] SUPPORTED_VERSIONS = new String[]{"1.3", "1.8"};
 

--- a/src/test/java/com/sparrowwallet/sparrow/net/BlockHeadersFormTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/BlockHeadersFormTest.java
@@ -1,0 +1,89 @@
+package com.sparrowwallet.sparrow.net;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.protocol.BlockHeader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Both forms a blockchain.block.headers response can take.
+ *
+ * Protocol 1.6 changed this field from concatenated hex to a list with one entry per header. Asking for 1.8 therefore changes the form this client
+ * is sent by any server capping between the version it used to ask for and this one, so reading only the concatenated form would break those servers
+ * on every chain, whether or not it has a v2 header anywhere in it.
+ */
+public class BlockHeadersFormTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    //A v1 header and a v2 header, so a run that mixes them is covered rather than only one length
+    private static final String V1 = "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299";
+    private static final String V2 = "000000a01f1e1d1c1b1a191817161514131211100f0e0d0c0b0a0908070605040302010000112233445566778899aabbccddeeff00102030405060708090a0b0c0d0e0f0a8913577ffff00200df0ad0b3a000000efcdab89ffeeddccbbaa998877665544332211005802000003005c000000000000000000000000000000000040d10c008967452301efcdab8967452301efcdab8967452301efcdab8967452301efcdab";
+
+    private BlockHeaders read(String json) throws Exception {
+        return MAPPER.readValue(json, BlockHeaders.class);
+    }
+
+    private List<BlockHeader> headersOf(BlockHeaders b, int count) {
+        return b.getHeaders(count);
+    }
+
+    @Test
+    public void the_concatenated_form_still_reads() throws Exception {
+        BlockHeaders b = read("{\"count\":2,\"max\":2016,\"hex\":\"" + V1 + V2 + "\"}");
+        List<BlockHeader> headers = headersOf(b, 2);
+        Assertions.assertNotNull(headers);
+        Assertions.assertEquals(2, headers.size());
+        Assertions.assertFalse(headers.get(0).isHeaderV2());
+        Assertions.assertTrue(headers.get(1).isHeaderV2());
+    }
+
+    @Test
+    public void the_list_form_reads_the_same_headers() throws Exception {
+        BlockHeaders concatenated = read("{\"count\":2,\"max\":2016,\"hex\":\"" + V1 + V2 + "\"}");
+        BlockHeaders list = read("{\"count\":2,\"max\":2016,\"hex\":[\"" + V1 + "\",\"" + V2 + "\"]}");
+
+        Assertions.assertEquals(concatenated.hex, list.hex);
+        List<BlockHeader> a = headersOf(concatenated, 2);
+        List<BlockHeader> b = headersOf(list, 2);
+        Assertions.assertNotNull(b);
+        Assertions.assertEquals(a.size(), b.size());
+        for(int i = 0; i < a.size(); i++) {
+            Assertions.assertArrayEquals(a.get(i).bitcoinSerialize(), b.get(i).bitcoinSerialize());
+        }
+    }
+
+    @Test
+    public void an_empty_list_is_an_empty_run() throws Exception {
+        BlockHeaders b = read("{\"count\":0,\"max\":2016,\"hex\":[]}");
+        Assertions.assertEquals("", b.hex);
+        Assertions.assertNotNull(headersOf(b, 0));
+        Assertions.assertTrue(headersOf(b, 0).isEmpty());
+    }
+
+    /**
+     * A list entry has to be one whole header. Refusing here rather than joining means a set of entries that are individually wrong but add up to a
+     * plausible run cannot be read as one.
+     */
+    @Test
+    public void a_list_entry_that_is_not_one_header_is_refused() throws Exception {
+        String half = V1.substring(0, V1.length() / 2);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[\"" + half + "\"]}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[\"" + V1 + V2 + "\"]}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[\"zz\"]}").hex);
+    }
+
+    @Test
+    public void neither_a_string_nor_a_list_is_refused() throws Exception {
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":17}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":null}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[1,2]}").hex);
+    }
+
+    @Test
+    public void the_client_asks_for_a_version_a_v2_chain_will_serve() {
+        Assertions.assertEquals("1.8", ElectrumServer.SUPPORTED_VERSIONS[ElectrumServer.SUPPORTED_VERSIONS.length - 1]);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/net/BlockHeadersFormTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/BlockHeadersFormTest.java
@@ -11,9 +11,9 @@ import java.util.List;
 /**
  * Both forms a blockchain.block.headers response can take.
  *
- * Protocol 1.6 changed this field from concatenated hex to a list with one entry per header. Asking for 1.8 therefore changes the form this client
- * is sent by any server capping between the version it used to ask for and this one, so reading only the concatenated form would break those servers
- * on every chain, whether or not it has a v2 header anywhere in it.
+ * Protocol 1.6 moved the run out of hex and into a headers field of its own, one entry per header. Asking for 1.8 therefore changes the form this
+ * client is sent by any server capping between the version it used to ask for and this one, so reading only the concatenated form would break those
+ * servers on every chain, whether or not it has a v2 header anywhere in it.
  */
 public class BlockHeadersFormTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -43,7 +43,7 @@ public class BlockHeadersFormTest {
     @Test
     public void the_list_form_reads_the_same_headers() throws Exception {
         BlockHeaders concatenated = read("{\"count\":2,\"max\":2016,\"hex\":\"" + V1 + V2 + "\"}");
-        BlockHeaders list = read("{\"count\":2,\"max\":2016,\"hex\":[\"" + V1 + "\",\"" + V2 + "\"]}");
+        BlockHeaders list = read("{\"count\":2,\"max\":2016,\"headers\":[\"" + V1 + "\",\"" + V2 + "\"]}");
 
         Assertions.assertEquals(concatenated.hex, list.hex);
         List<BlockHeader> a = headersOf(concatenated, 2);
@@ -57,7 +57,7 @@ public class BlockHeadersFormTest {
 
     @Test
     public void an_empty_list_is_an_empty_run() throws Exception {
-        BlockHeaders b = read("{\"count\":0,\"max\":2016,\"hex\":[]}");
+        BlockHeaders b = read("{\"count\":0,\"max\":2016,\"headers\":[]}");
         Assertions.assertEquals("", b.hex);
         Assertions.assertNotNull(headersOf(b, 0));
         Assertions.assertTrue(headersOf(b, 0).isEmpty());
@@ -70,16 +70,52 @@ public class BlockHeadersFormTest {
     @Test
     public void a_list_entry_that_is_not_one_header_is_refused() throws Exception {
         String half = V1.substring(0, V1.length() / 2);
-        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[\"" + half + "\"]}").hex);
-        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[\"" + V1 + V2 + "\"]}").hex);
-        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[\"zz\"]}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"headers\":[\"" + half + "\"]}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"headers\":[\"" + V1 + V2 + "\"]}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"headers\":[\"zz\"]}").hex);
     }
 
+    /** A headers field that is not a list of hex strings leaves nothing to read, rather than something partly read. */
     @Test
-    public void neither_a_string_nor_a_list_is_refused() throws Exception {
-        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":17}").hex);
-        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":null}").hex);
-        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"hex\":[1,2]}").hex);
+    public void a_headers_field_that_is_not_a_list_is_refused() throws Exception {
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"headers\":[1,2]}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"headers\":\"" + V1 + "\"}").hex);
+        Assertions.assertNull(read("{\"count\":1,\"max\":2016,\"headers\":null}").hex);
+    }
+
+    /** The two forms are exclusive, so a response carrying only the old field is unaffected by the new one existing. */
+    @Test
+    public void the_concatenated_form_is_not_disturbed_by_the_new_field() throws Exception {
+        BlockHeaders b = read("{\"count\":1,\"max\":2016,\"hex\":\"" + V1 + "\"}");
+        Assertions.assertEquals(V1, b.hex);
+        Assertions.assertEquals(1, headersOf(b, 1).size());
+    }
+
+    /**
+     * Not a shape written here from reading the protocol, but the response a Fulcrum 2.1.2 actually returned once this client asked for a range
+     * reaching past 1.6. The first fixture written for this was invented, put the list under hex, and passed against a server that does not exist.
+     */
+    @Test
+    public void a_response_a_real_server_sent() throws Exception {
+        BlockHeaders b = read("{\"count\":3,\"headers\":[\"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2002000000\",\"0000002006226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910fdc2dac016f2b3f4f356b30114a22a291ac643b82dd8a6af247c6d23428791849e8889b6affff7f2000000000\",\"0000002062fab197b7b201627d8673f3e6cb278394f98ee25e25f79e6391233575804e112de13277c4f93d6276bf83aaa0b8147c9e5775339d97fd87f737b4a2c287c2c9e9889b6affff7f2000000000\"],\"max\":2016}");
+        List<BlockHeader> headers = headersOf(b, 3);
+        Assertions.assertNotNull(headers, "the run a real server sent did not split into headers");
+        Assertions.assertEquals(3, headers.size());
+        Assertions.assertEquals("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", headers.get(0).getHash().toString());
+        for(int i = 1; i < headers.size(); i++) {
+            Assertions.assertEquals(headers.get(i - 1).getHash(), headers.get(i).getPrevBlockHash(), "the run does not link");
+        }
+    }
+
+    /** Every entry can be a valid header and the run still be larger than this call can legitimately return, so the join stops rather than growing. */
+    @Test
+    public void a_run_larger_than_the_call_can_return_is_refused() throws Exception {
+        StringBuilder list = new StringBuilder("{\"count\":1,\"max\":2016,\"headers\":[");
+        for(int i = 0; i < 4200; i++) {
+            list.append(i == 0 ? "" : ",").append('"').append(V1).append('"');
+        }
+        list.append("]}");
+        Assertions.assertNull(read(list.toString()).hex);
     }
 
     @Test

--- a/src/test/java/com/sparrowwallet/sparrow/net/Protocol18WireTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/Protocol18WireTest.java
@@ -1,0 +1,136 @@
+package com.sparrowwallet.sparrow.net;
+
+import com.google.common.net.HostAndPort;
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.protocol.BlockHeader;
+import com.sparrowwallet.sparrow.SparrowWallet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Over a socket, against a server that behaves the way a server on a chain with v2 headers is specified to.
+ *
+ * The two halves this exercises cannot be reached below the JSON layer, which is where the rest of the header tests fake their answers: whether the
+ * version this client asks for is one such a server will serve at all, and whether the list form that asking for it produces can be read.
+ */
+public class Protocol18WireTest {
+    @TempDir
+    private static Path tempHome;
+
+    private static final String V1 = "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299";
+    private static final String V2 = "000000a01f1e1d1c1b1a191817161514131211100f0e0d0c0b0a0908070605040302010000112233445566778899aabbccddeeff00102030405060708090a0b0c0d0e0f0a8913577ffff00200df0ad0b3a000000efcdab89ffeeddccbbaa998877665544332211005802000003005c000000000000000000000000000000000040d10c008967452301efcdab8967452301efcdab8967452301efcdab8967452301efcdab";
+
+    @BeforeAll
+    public static void setUp() {
+        System.setProperty(SparrowWallet.APP_HOME_PROPERTY, tempHome.toString());
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        System.clearProperty(SparrowWallet.APP_HOME_PROPERTY);
+    }
+
+    /** Refuses below 1.8 and answers blockchain.block.headers with the list form, as protocol 1.6 and later specify. */
+    private Thread serve(ServerSocket serverSocket, StringBuilder negotiated) {
+        Thread t = new Thread(() -> {
+            try(Socket socket = serverSocket.accept();
+                BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+                PrintWriter out = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8), true)) {
+                String line;
+                while((line = in.readLine()) != null) {
+                    int id = Integer.parseInt(line.replaceAll(".*\"id\"\\s*:\\s*(\\d+).*", "$1"));
+                    if(line.contains("server.version")) {
+                        negotiated.append(line);
+                        if(!line.contains("\"1.8\"")) {
+                            out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"error\":{\"code\":1,\"message\":"
+                                    + "\"unsupported request: this chain uses 164-byte block headers with a BLAKE2b block hash\"}}");
+                        } else {
+                            out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":[\"ElectrumStub 1.0\",\"1.8\"]}");
+                        }
+                    } else if(line.contains("blockchain.block.headers")) {
+                        //The list form, one entry per header, mixing the two lengths
+                        out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":{\"count\":2,\"max\":2016,"
+                                + "\"hex\":[\"" + V1 + "\",\"" + V2 + "\"]}}");
+                    } else {
+                        out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":null}");
+                    }
+                }
+            } catch(Exception e) {
+                //the socket closing at the end of a test is expected
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
+    /** As the wallet does it: open the socket, then read replies on a thread of their own, which is what pass() waits on. */
+    private TcpTransport connected(ServerSocket serverSocket) throws Exception {
+        TcpTransport transport = new TcpTransport(HostAndPort.fromParts("127.0.0.1", serverSocket.getLocalPort()));
+        transport.connect();
+        Thread reader = new Thread(() -> {
+            try {
+                transport.readInputLoop();
+            } catch(Exception e) {
+                //the transport closing at the end of a test is expected
+            }
+        });
+        reader.setDaemon(true);
+        reader.start();
+        return transport;
+    }
+
+    @Test
+    public void the_version_asked_for_is_one_such_a_server_serves() throws Exception {
+        try(ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            StringBuilder negotiated = new StringBuilder();
+            serve(serverSocket, negotiated);
+            TcpTransport transport = connected(serverSocket);
+            try {
+                List<String> version = new SimpleElectrumServerRpc().getServerVersion(transport, SparrowWallet.APP_NAME, ElectrumServer.SUPPORTED_VERSIONS);
+                Assertions.assertEquals("1.8", version.get(1), "the server agreed a version below 1.8, which it would refuse to serve headers at");
+                Assertions.assertTrue(negotiated.toString().contains(SparrowWallet.APP_NAME),
+                        "the client named itself something other than this wallet");
+            } finally {
+                transport.close();
+            }
+        }
+    }
+
+    @Test
+    public void the_list_form_that_asking_for_it_produces_is_read() throws Exception {
+        try(ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            serve(serverSocket, new StringBuilder());
+            TcpTransport transport = connected(serverSocket);
+            try {
+                SimpleElectrumServerRpc rpc = new SimpleElectrumServerRpc();
+                rpc.getServerVersion(transport, SparrowWallet.APP_NAME, ElectrumServer.SUPPORTED_VERSIONS);
+                BlockHeaders headers = rpc.getBlockHeadersChunk(transport, 0, 2);
+
+                List<BlockHeader> parsed = headers.getHeaders(2);
+                Assertions.assertNotNull(parsed, "the list form did not split into headers");
+                Assertions.assertEquals(2, parsed.size());
+                Assertions.assertFalse(parsed.get(0).isHeaderV2());
+                Assertions.assertTrue(parsed.get(1).isHeaderV2(), "the v2 header was not recognised over the wire");
+                Assertions.assertEquals(BlockHeader.V2_LENGTH, parsed.get(1).getLength());
+                Assertions.assertArrayEquals(Utils.hexToBytes(V2), parsed.get(1).bitcoinSerialize());
+            } finally {
+                transport.close();
+            }
+        }
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/net/Protocol18WireTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/Protocol18WireTest.java
@@ -62,9 +62,9 @@ public class Protocol18WireTest {
                             out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":[\"ElectrumStub 1.0\",\"1.8\"]}");
                         }
                     } else if(line.contains("blockchain.block.headers")) {
-                        //The list form, one entry per header, mixing the two lengths
+                        //The list form as Fulcrum sends it at 1.6 and above: a headers field, one entry per header, mixing the two lengths
                         out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":{\"count\":2,\"max\":2016,"
-                                + "\"hex\":[\"" + V1 + "\",\"" + V2 + "\"]}}");
+                                + "\"headers\":[\"" + V1 + "\",\"" + V2 + "\"]}}");
                     } else {
                         out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":null}");
                     }


### PR DESCRIPTION
Closes #22.

The electrs build that indexes this chain refuses to negotiate below Electrum protocol 1.8, and this wallet asked for a maximum of 1.4.2. The connection was declined before a single header was fetched, so the wallet could not sync against its own chain at all.

## What changed

The negotiated range is now `1.3` to `1.8`. It is a minimum and a maximum, so every other server still settles on the highest version it supports within it.

That alone is not enough, and the reason is a consequence of the bump rather than of the header format. Protocol 1.6 moved the run of headers out of the `hex` field of a `blockchain.block.headers` response and into a `headers` field of its own, one hex string per header. A server answers in whichever form the negotiated version calls for, so reaching past 1.6 on the way to 1.8 changes the form this wallet is sent by every server capping in between, on any chain. Measured here: a Fulcrum 2.1.2 answers the old range at 1.4.2 with the concatenated string and the new range at 1.6 with the list. Reading only the old field would have traded one broken set of servers for a larger one.

`BlockHeaders` now reads both. The list is joined back into the run the rest of the class already walks, an entry that is not one whole header is refused there rather than concatenated into a run that happens to add up, and the join stops once it passes the largest run this call can legitimately return. Header length still comes from each header's own version word, which was already the case.

## Verification

Against two real servers, on a regtest chain, driving the wallet's own transport and RPC rather than a fake:

- **Fulcrum 2.1.2**, which caps at 1.6: negotiates 1.6, sends the list, and the headers parse and link from genesis. With the field name reverted, the same server produces `Malformed response to a request for 4 block headers from height 0` on every range, which is what shipping the first version of this would have done to anyone running Fulcrum.
- **electrs 0.11.1**, which caps at 1.4: clamps the range rather than refusing it, negotiates 1.4, sends the concatenated string, and still parses. This is the case that confirms the bump does not break servers that know nothing about 1.8.

In the suite, `BlockHeadersFormTest` covers both forms, an empty list, a malformed entry, a run larger than the call can return, and a `headers` field that is not a list. One of its fixtures is a response captured verbatim from the Fulcrum above rather than written by hand. `Protocol18WireTest` runs the real transport over a socket against a stub that refuses below 1.8, covering the negotiation that a JSON-level test cannot reach.

Each test was checked against a mutant: reverting the version bump fails both wire tests, and reverting the field name fails the list tests while leaving the version test passing.

Full suite: 1052 tests, 0 failures.

## Not covered

Both servers above were serving a chain with no v2 headers on it, so the 164 byte header path was exercised by fixtures and unit tests rather than by a live server. Walking a mixed run by each header's own length is unchanged by this PR and was already covered.
