### PR TITLE
Point the security policy and signing key at this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Sparrow is licensed under the Apache 2 software licence.
 
 ## GPG Key
 
-The Sparrow release binaries here and on [sparrowwallet.com](https://sparrowwallet.com/download/) are signed using [craigraw's GPG key](https://keybase.io/craigraw):  
+Sparrow's own release binaries, on [sparrowwallet.com](https://sparrowwallet.com/download/), are signed using [craigraw's GPG key](https://keybase.io/craigraw). The releases in this repository are not: they are signed with the key under [Releases](#releases) above.  
 Fingerprint: D4D0D3202FC06849A257B38DE94618334C674B40  
 64-bit: E946 1833 4C67 4B40
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,15 +4,17 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, report them privately using GitHub's [Security tab](https://github.com/sparrowwallet/sparrow/security/advisories/new) for this repository. This creates a private security advisory visible only to you and the maintainers.
+Instead, report them privately using GitHub's [Security tab](https://github.com/privkeyio/shrike/security/advisories/new) for this repository. This creates a private security advisory visible only to you and the maintainers.
 
-If you are unable to use GitHub, you may email mail@sparrowwallet.com. Sensitive reports can be encrypted to [craigraw's GPG key](https://keybase.io/craigraw) (fingerprint `D4D0D3202FC06849A257B38DE94618334C674B40`).
+If you are unable to use GitHub, you may email kyle@privkey.io. Sensitive reports can be encrypted to the key the releases are signed with, `privkeyio-signing-key.asc` on any [release](https://github.com/privkeyio/shrike/releases) (fingerprint `A47D99B6DB0D715D40C59A2023AE8A8EA7E24E38`).
+
+Vulnerabilities in upstream Sparrow that are not specific to this project belong with [Sparrow's own policy](https://github.com/sparrowwallet/sparrow/blob/master/SECURITY.md) instead, since a fix there reaches far more users.
 
 ### What to include
 
 To help triage the report quickly, please include as much of the following as you can:
 
-- The Sparrow version, operating system, and how Sparrow was installed (installer, package, or built from source)
+- The Shrike version, operating system, and how it was installed (installer, package, or built from source)
 - A description of the vulnerability and its impact
 - Steps to reproduce, ideally with a proof of concept
 - Any relevant configuration (network, wallet type, connected server or hardware wallet)
@@ -29,7 +31,7 @@ Fixes for serious issues are generally released as soon as they are ready, rathe
 
 ### Disclosure
 
-Sparrow follows the [Bitcoin Core Security Disclosure Policy](https://bitcoincore.org/en/security-advisories/). Reports are assigned one of four severity levels, which determines when details are made public:
+Shrike follows the [Bitcoin Core Security Disclosure Policy](https://bitcoincore.org/en/security-advisories/). Reports are assigned one of four severity levels, which determines when details are made public:
 
 | Severity | Description | Disclosure                                  |
 | --- | --- |---------------------------------------------|
@@ -46,17 +48,17 @@ For Medium and High severity issues, the advisory is published once the disclosu
 
 Please give us the opportunity to release a fix before disclosing the issue publicly. If you intend to disclose on a timeline of your own, say so in your report so it can be discussed early.
 
-There is currently no bug bounty programme for Sparrow.
+There is currently no bug bounty program for Shrike.
 
 ## Supported Versions
 
-Security fixes are made against the latest release only. Users are encouraged to run the most recent version, available from [sparrowwallet.com](https://sparrowwallet.com/download/) or the [GitHub releases](https://github.com/sparrowwallet/sparrow/releases) page.
+Security fixes are made against the latest release only. Users are encouraged to run the most recent version, available from the [releases](https://github.com/privkeyio/shrike/releases) page.
 
-Release binaries are signed with the GPG key above, and are [reproducible from source](docs/reproducible.md) from v1.5.0 onwards. Verifying the signature on a download before installing is strongly recommended.
+Release binaries are signed with the GPG key above, and are [reproducible from source](docs/reproducible.md). Verifying the signature on a download before installing is strongly recommended.
 
 ## Scope
 
-This policy covers Sparrow and its submodules, [Drongo](https://github.com/sparrowwallet/drongo) (Bitcoin protocol and wallet primitives) and [Lark](https://github.com/sparrowwallet/lark) (USB hardware wallet interaction). Report issues in any of them here rather than on the submodule repositories, so that a fix and a Sparrow release can be coordinated.
+This policy covers Shrike and its submodules, [Drongo](https://github.com/privkeyio/drongo) (Bitcoin protocol and wallet primitives) and [Lark](https://github.com/privkeyio/lark) (USB hardware wallet interaction). Report issues in any of them here rather than on the submodule repositories, so that a fix and a release can be coordinated.
 
 Examples of issues we are particularly interested in:
 
@@ -69,7 +71,7 @@ Examples of issues we are particularly interested in:
 
 The following are generally out of scope:
 
-- Vulnerabilities in third-party servers, hardware wallet firmware, or upstream dependencies, which should be reported to the relevant project (though we appreciate being told where Sparrow's use of them makes the impact worse)
+- Vulnerabilities in third-party servers, hardware wallet firmware, or upstream dependencies, which should be reported to the relevant project (though we appreciate being told where this wallet's use of them makes the impact worse)
 - Attacks requiring an already compromised operating system, or physical access to an unlocked machine
 - Missing hardening or best-practice recommendations without a demonstrated impact
 - Reports generated by automated scanners or language models where the reporter has not independently verified the issue and demonstrated its impact. A plausible-sounding description of a vulnerability is not a vulnerability; if you cannot reproduce it, we are unlikely to be able to either


### PR DESCRIPTION
The security policy was still upstream's. GitHub shows it as this repository's policy, so a vulnerability found in the opt-in signing path, which upstream does not have, was directed to Sparrow's advisory page and to mail@sparrowwallet.com, encrypted to a key nobody here holds. Sparrow would have received reports about code they did not write, and the reporter would have waited on a fix from a project that cannot make one.

Reports now go to this repository's advisory page or to kyle@privkey.io, encrypted to the key the releases are already signed with. A vulnerability in upstream Sparrow that is not specific to this project is pointed at Sparrow's own policy instead, since a fix there reaches far more users. The submodule links follow the forks this actually builds against, and the version and supported-release wording names this project.

The README carried the same confusion in a more dangerous form: under GPG Key it said the release binaries "here" are signed with craigraw's key, which is upstream's. Anyone verifying a download from this repository against that key gets a failure that looks like a tampered file. It now says plainly that Sparrow's binaries are signed with that key and this repository's are not, pointing at the signing key already documented above it.

What is deliberately unchanged:

- `.mailmap` maps the git identities of upstream commits. Rewriting it would attribute their work to someone else.
- `gradle/verification-keyring.keys` holds a real Sonatype key that happens to carry that uid, and is used to verify dependencies. Editing it breaks dependency verification.
- The craigraw fingerprint stays in the GPG Key section, because that key genuinely does sign Sparrow's downloads. Renaming it would make the statement false rather than correct.
