### PR TITLE
Only say replay protected when a signature was actually checked

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -18,6 +18,8 @@ import com.sparrowwallet.sparrow.control.WalletPasswordDialog;
 import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
 import com.sparrowwallet.sparrow.net.Auth47;
 import com.sparrowwallet.drongo.policy.Policy;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptChunk;
 import com.sparrowwallet.drongo.protocol.BlockHeader;
 import com.sparrowwallet.drongo.protocol.ScriptType;
 import com.sparrowwallet.drongo.protocol.Sha256Hash;
@@ -77,6 +79,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.sparrowwallet.sparrow.AppController.CONNECTION_FAILED_PREFIX;
@@ -1026,7 +1029,7 @@ public class AppServices {
      *
      * A PSBT carries one hash type for every signer, so opting in needs enough of them marked to meet the threshold.
      */
-    static UnifiedSigHashDecision keystoreDecision(Wallet wallet) {
+    public static UnifiedSigHashDecision keystoreDecision(Wallet wallet) {
         if(wallet == null || wallet.getKeystores().isEmpty()) {
             return UnifiedSigHashDecision.NO_SIGNING_KEYS;
         }
@@ -1092,35 +1095,203 @@ public class AppServices {
      *
      * Read off the signatures rather than the declared hash type, because a transaction assembled from per-device
      * PSBTs carries signatures the declaration does not describe.
+     *
+     * How many signatures opt in, how many could be checked, and how many are there.
+     *
+     * The first two count only signatures verified against a key the caller vouches for, since any 64 or 65 byte
+     * push decodes as a Schnorr signature carrying whatever byte it ends with. The third counts everything signature
+     * shaped, so one that could not be checked weakens the claim rather than vanishing from it.
      */
-    public static int[] signatureOptInCounts(PSBT psbt) {
+    public static int[] signatureOptInCounts(PSBT psbt, Wallet wallet) {
         if(psbt == null) {
-            return new int[] {0, 0};
+            return new int[] {0, 0, 0};
         }
 
-        int optedIn = 0;
-        int total = 0;
-        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
-            for(TransactionSignature signature : psbtInput.getSignatures()) {
-                total++;
-                if((signature.sighashFlags & SigHash.UNIFIED_FLAG) != 0) {
-                    optedIn++;
-                }
+        //Guarded: a derivation naming this wallet's fingerprint with a hardened path throws, and an exception
+        //here would abandon the update and leave the label saying whatever it said before.
+        Map<PSBTInput, WalletNode> signingNodes;
+        try {
+            signingNodes = wallet == null ? Map.of() : wallet.getSigningNodes(psbt);
+        } catch(RuntimeException e) {
+            log.warn("Could not work out which inputs this wallet signs for", e);
+            signingNodes = Map.of();
+        }
+
+        Map<PSBTInput, WalletNode> nodes = signingNodes;
+
+        //Answered once per node rather than once per input. Working out what a wallet vouches for derives a key for
+        //every keystore, twice, and nothing bounds how many inputs ask: a PSBT that repeats one script this wallet
+        //owns across ten thousand inputs fits under a megabyte and asked for three hundred thousand derivations
+        //before any of the ceilings below could apply. The answer is a property of the node, so the inputs after the
+        //first cost nothing.
+        Map<WalletNode, Collection<ECKey>> byNode = new HashMap<>();
+
+        return signatureOptInCounts(psbt, psbtInput -> {
+            WalletNode node = nodes.get(psbtInput);
+            if(node == null) {
+                return Set.of();
             }
-        }
 
-        return new int[] {optedIn, total};
+            return byNode.computeIfAbsent(node, vouchedFor -> trustedKeys(psbtInput, wallet, vouchedFor));
+        });
     }
 
     /**
-     * How many signatures in this transaction can be lifted out of it and spent against nodes that have not
-     * kept up.
+     * The keys this wallet will stand behind for an input, or none.
      *
-     * One opted-in signature makes the whole transaction invalid under the pre-fork rules, but the legacy signatures
-     * inside it stay individually valid there. A legacy ALL or SINGLE signature commits to every input, so it is
-     * useless in any other transaction. A legacy ANYONECANPAY one commits only to its own input and to the outputs,
-     * so it can be copied into a transaction that drops the opted-in inputs and spent against a node that never
-     * kept up. The transaction is protected; that input is not, and saying only "protected" would hide it.
+     * The spent output must be the one this wallet derives for that node: the message is built entirely from the
+     * PSBT, amount included, so otherwise a stranger chose the message the signature verifies over.
+     */
+    static Set<ECKey> trustedKeys(PSBTInput psbtInput, Wallet wallet, WalletNode walletNode) {
+        if(wallet == null || walletNode == null || psbtInput.getUtxo() == null) {
+            return Set.of();
+        }
+
+        //The node's own wallet, which for a nested one is a child: the outer wallet's script type would answer
+        //for a script nobody holds
+        wallet = walletNode.getWallet() != null ? walletNode.getWallet() : wallet;
+
+        //A wallet built out of the PSBT vouches for nothing: every check below would be the file agreeing with itself
+        if(wallet instanceof FinalizingPSBTWallet) {
+            return Set.of();
+        }
+
+        Script walletScript;
+        try {
+            walletScript = wallet.getOutputScript(walletNode);
+        } catch(RuntimeException e) {
+            //Deriving reaches the keystores and can throw; no exception may leave a label
+            return Set.of();
+        }
+
+        if(walletScript == null || !walletScript.equals(psbtInput.getUtxo().getScript())) {
+            return Set.of();
+        }
+
+        //getPubKeys throws for a singlesig wallet rather than answering with the one key, so ask by policy
+        Set<ECKey> keys = new LinkedHashSet<>();
+        try {
+            if(ScriptType.P2TR.isScriptType(walletScript)) {
+                //Only the output key authorises a key path spend, not the untweaked key it came from
+                keys.add(ScriptType.P2TR.getPublicKeyFromScript(walletScript));
+            } else if(wallet.getPolicyType() == PolicyType.MULTI_HD) {
+                keys.addAll(walletNode.getPubKeys());
+            } else {
+                keys.add(walletNode.getPubKey());
+            }
+        } catch(RuntimeException e) {
+            //A wallet that cannot answer for a node vouches for nothing
+            return Set.of();
+        }
+        keys.remove(null);
+        return keys;
+    }
+
+    /**
+     * As above, vouching for a set of keys directly rather than through a wallet.
+     *
+     * Deliberately not public: the keys are taken on trust. Never pass keys read out of a PSBT, or whoever wrote
+     * the file can satisfy the check.
+     */
+    static int[] signatureOptInCounts(PSBT psbt, Collection<ECKey> trustedKeys) {
+        return psbt == null ? new int[] {0, 0, 0} : signatureOptInCounts(psbt, psbtInput -> trustedKeys);
+    }
+
+    private static int[] signatureOptInCounts(PSBT psbt, Function<PSBTInput, Collection<ECKey>> keysFor) {
+        //Two ceilings, because the two costs are not the same. getVerifiedSignatures builds one message per distinct
+        //hash type and keeps it, so an input costs one message however many keys vouch for it, and verifying against
+        //a key is constant time after that. Messages are charged by what they hash and checks against a flat ceiling.
+        //Charging checks against the message budget was what left a 2 of 3 consolidation reading "not checked": it
+        //paid six times what it spends, and stopped a third of the way through.
+        int inputCount = Math.max(1, psbt.getPsbtInputs().size());
+        long checkBudget = Math.min((long)MAX_INPUT_SIGNATURE_CHECKS * inputCount, MAX_SIGNATURE_CHECKS);
+
+        int optedIn = 0;
+        int verified = 0;
+        int total = 0;
+        int checked = 0;
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            //Charged only for work that can happen. An input refused before any check runs costs nothing, or crafted
+            //inputs would spend the budget and silence every honest input after them.
+            //Refused before anything is parsed. Every other ceiling here counts signatures, and a witness may carry
+            //any number of pushes that are not signature shaped: each is still parsed and offered to the signature
+            //decoder, three times over, and a hundred inputs of a hundred thousand of them measured two and a half
+            //minutes. No spend needs anything like this many, and the count is already to hand.
+            if(pushCount(psbtInput) > MAX_INPUT_PUSHES) {
+                //Present and unreadable, which is the answer this owes for an input it will not look at
+                total += MAX_INPUT_PUSHES;
+                continue;
+            }
+
+            Collection<ECKey> keys = keysFor.apply(psbtInput);
+            //A partial signature names the key that made it, so an input still carrying them costs one check each
+            //rather than a check against every key. Asked of the input rather than worked out again here, because
+            //this has to predict what getVerifiedSignatures will do and the two drifting is how a foreign input came
+            //to be charged for checks nobody was going to make.
+            boolean namesItsKeys = psbtInput.namesItsKeys();
+            //Read once: on a finalised input this parses the witness and tries to decode every push
+            Collection<TransactionSignature> signatures = psbtInput.getSignatures();
+            //Nothing vouched for is nothing to check, and must cost nothing. Dropping the keys factor for an input
+            //that names its keys dropped the reason this was zero for a foreign input, so enough of them ahead of the
+            //wallet's own spent the budget without a check being made, which is the silencing this guards against.
+            long wouldCheck = keys.isEmpty() ? 0
+                    : (namesItsKeys ? signatures.size() : (long)keys.size() * signatures.size());
+            //Taproot script path signatures can never be verified here, since the leaf script is not parsed, so they
+            //only hold the answer open. Bounded, but deliberately not narrowed to taproot or unfinalised inputs:
+            //isTaproot needs a spent output the PSBT may omit, and either narrowing drops an entry from both counts,
+            //letting a transaction read as fully checked while carrying something nobody looked at.
+            int unverifiable = Math.min(psbtInput.getTapScriptSignatures().size(), MAX_INPUT_SIGNATURE_CHECKS);
+            int inputTotal = signatures.size() + unverifiable;
+
+            try {
+                //Inside the guard: working out whether this input can be checked reads a script that can fail to read
+                boolean canCheck = wouldCheck > 0 && wouldCheck <= MAX_INPUT_SIGNATURE_CHECKS
+                        && psbtInput.getUtxo() != null && psbtInput.getSigningScript() != null;
+                if(!canCheck || checked + wouldCheck > checkBudget) {
+                    keys = List.of();
+                    wouldCheck = 0;
+                }
+                checked += (int)wouldCheck;
+
+                List<TransactionSignature> verifiedHere = psbtInput.getVerifiedSignatures(keys);
+
+                //Counted from what could be a signature, not every push that decodes as one: an uncompressed public
+                //key and a control block are both 65 bytes. Only where this input was checked, or the filter drops a
+                //skipped input from both counts and settles on "not protected" over something never looked at.
+                if(!keys.isEmpty()) {
+                    inputTotal = Math.max(verifiedHere.size(), liftableCandidates(psbtInput).size()) + unverifiable;
+                }
+
+                for(TransactionSignature signature : verifiedHere) {
+                    verified++;
+                    if((signature.sighashFlags & SigHash.UNIFIED_FLAG) != 0) {
+                        optedIn++;
+                    }
+                }
+            } catch(RuntimeException e) {
+                //A check that cannot run must not read as one that failed, nor take the screen with it
+                log.warn("Could not check the signatures on an input for the opt-in", e);
+            }
+
+            total += inputTotal;
+        }
+
+        return new int[] {optedIn, verified, total};
+    }
+
+    /** What one input may ask for, matching drongo's own ceiling, and what a whole transaction may. */
+    private static final int MAX_INPUT_SIGNATURE_CHECKS = 1024;
+    //Measured at about 52 microseconds a verify, so this is a fifth of a second in the worst case a crafted PSBT can
+    //arrange, on the thread that is drawing. It was 16384, which measured 855ms and froze the window.
+    private static final int MAX_SIGNATURE_CHECKS = 4096;
+
+
+    /**
+     * Signatures that can be lifted out of this transaction and spent on the SHA256d chain.
+     *
+     * Counted from every push that could be a signature rather than only those that verify, because this reports a
+     * risk: naming one that is not there costs a warning, missing one that is costs the warning that mattered.
+     * Pushes provably not signatures are still left out, or the warnings about something get ignored too.
      */
     public static int liftableSignatureCount(PSBT psbt) {
         if(psbt == null) {
@@ -1128,16 +1299,112 @@ public class AppServices {
         }
 
         int liftable = 0;
+        int examined = 0;
         for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
-            for(TransactionSignature signature : psbtInput.getSignatures()) {
+            //Bounded, because the pushes are the PSBT's to choose and nothing else here caps them: four million of
+            //them measured two seconds on the thread that draws, and reported a count no sentence should carry.
+            //Stopping early can only leave a warning unsaid, and a transaction that reaches this cap is already
+            //reading as not checked from the counts, which is the stronger thing to say about it.
+            if(examined >= MAX_LIFTABLE_PUSHES) {
+                break;
+            }
+
+            //As in the counting, and for the same reason: the walk below is per push, not per signature
+            if(pushCount(psbtInput) > MAX_INPUT_PUSHES) {
+                continue;
+            }
+
+            for(TransactionSignature signature : liftableCandidates(psbtInput)) {
+                if(++examined > MAX_LIFTABLE_PUSHES) {
+                    break;
+                }
+
                 if((signature.sighashFlags & SigHash.UNIFIED_FLAG) == 0
                         && (signature.sighashFlags & SigHash.ANYONECANPAY.value) != 0) {
+                    liftable++;
+                }
+            }
+
+            //And the script path ones, which liftableCandidates does not reach: those travel in a field of their own
+            //Capped as the denominator caps them, so the two numbers a sentence quotes cannot disagree
+            int scriptPath = 0;
+            for(String signature : psbtInput.getTapScriptSignatures().values()) {
+                if(++examined > MAX_LIFTABLE_PUSHES || ++scriptPath > MAX_INPUT_SIGNATURE_CHECKS) {
+                    break;
+                }
+
+                //64 bytes carries no hash type byte at all, which is the default type, and that commits to every input
+                if(signature.length() != 130) {
+                    continue;
+                }
+
+                int sighashFlags = Integer.parseInt(signature.substring(128), 16);
+                if((sighashFlags & SigHash.UNIFIED_FLAG) == 0 && (sighashFlags & SigHash.ANYONECANPAY.value) != 0) {
                     liftable++;
                 }
             }
         }
 
         return liftable;
+    }
+
+    /**
+     * How many pushes an input carries, without parsing any of them. A witness holds its pushes as a list already,
+     * and a script its chunks, so both are to hand: what costs is offering each of them to the signature decoder.
+     */
+    private static int pushCount(PSBTInput psbtInput) {
+        int pushes = psbtInput.getFinalScriptWitness() == null ? 0 : psbtInput.getFinalScriptWitness().getPushes().size();
+        return pushes + (psbtInput.getFinalScriptSig() == null ? 0 : psbtInput.getFinalScriptSig().getChunks().size());
+    }
+
+    /**
+     * The most pushes an input is worth reading. A twenty of twenty multisig witness carries twenty three, and
+     * consensus will not check more keys than that, so anything past this is not a spend.
+     */
+    private static final int MAX_INPUT_PUSHES = 1024;
+
+    /**
+     * How many pushes the liftable warning will look at across a transaction. Measured at about a third of a
+     * microsecond each, so this is a small fraction of a second on the drawing thread.
+     */
+    private static final int MAX_LIFTABLE_PUSHES = 50_000;
+
+    /**
+     * The pushes on an input that could be a signature. A partial signature is one by construction; on a finalised
+     * input the pushes a script puts there for another purpose, a public key and a control block, are excluded.
+     */
+    private static List<TransactionSignature> liftableCandidates(PSBTInput psbtInput) {
+        if(psbtInput.getFinalScriptSig() == null && psbtInput.getFinalScriptWitness() == null) {
+            return new ArrayList<>(psbtInput.getSignatures());
+        }
+
+        List<ScriptChunk> chunks = new ArrayList<>();
+        if(psbtInput.getFinalScriptSig() != null) {
+            chunks.addAll(psbtInput.getFinalScriptSig().getChunks());
+        }
+        if(psbtInput.getFinalScriptWitness() != null) {
+            chunks.addAll(psbtInput.getFinalScriptWitness().asScriptChunks());
+        }
+
+        List<TransactionSignature> candidates = new ArrayList<>();
+        for(int i = 0; i < chunks.size(); i++) {
+            ScriptChunk chunk = chunks.get(i);
+            if(!chunk.isSignature()) {
+                continue;
+            }
+
+            //Both are shape tests, and a Schnorr signature meets one about three times in 256: 65 bytes beginning
+            //0xc0 or 0xc1 reads as a control block, 65 beginning 0x04 as an uncompressed key. Applied by shape alone
+            //they discard the single push a taproot key path spend finalises to. Those pushes sit last, after the
+            //signatures, so only there is the shape worth believing.
+            if(i == chunks.size() - 1 && chunks.size() > 1 && (chunk.isPubKey() || chunk.isTaprootControlBlock())) {
+                continue;
+            }
+
+            candidates.add(chunk.getSignature());
+        }
+
+        return candidates;
     }
 
     /**
@@ -1325,6 +1592,46 @@ public class AppServices {
      * The decision and everything qualifying it, taken from one reading of the chain tip so the two agree.
      */
     public record UnifiedSigHashStatus(UnifiedSigHashDecision decision, List<String> caveats) {
+    }
+
+    /**
+     * What the chain has to say about an opt-in, for a caller whose headline is about the signers.
+     *
+     * Only a keystore mark strips a hash type a PSBT already declares, so keystoreDecision answers that on its own.
+     * The chain answers whether this wallet would opt in at all, which explains nothing about what signs anything,
+     * and is said separately rather than dropped.
+     */
+    public static List<String> chainQualifications() {
+        ChainTip tip = decisionTip();
+        return chainQualifications(chainDecision(Network.get(), tip == null ? null : tip.height(), tip == null ? null : tip.header()));
+    }
+
+    /**
+     * The rule itself, taking the decision so it can be exercised without a chain, as chainDecision is.
+     *
+     * Only ever a chainDecision. Handed a keystore decision it would say the chain declined for a reason belonging to
+     * the signers, which is the splice the two are kept apart to prevent.
+     */
+    static List<String> chainQualifications(UnifiedSigHashDecision chain) {
+        if(chain.isOptedIn()) {
+            return chain.getCaveat() == null ? List.of() : List.of(chain.getCaveat());
+        }
+
+        List<String> qualifications = new ArrayList<>();
+        qualifications.add("Separately, " + chain.getReason() + ", so this wallet would not itself opt in as things stand.");
+        if(chain.getRemedy() != null) {
+            qualifications.add(chain.getRemedy());
+        }
+
+        return List.copyOf(qualifications);
+    }
+
+    /**
+     * What qualifies the signers' answer, with the marked signers named, which is the half a reader can act on.
+     */
+    public static String keystoreCaveat(Wallet wallet) {
+        UnifiedSigHashDecision keystores = keystoreDecision(wallet);
+        return keystores.getCaveat() == null ? null : keystores.getCaveat() + markedSignerSuffix(wallet);
     }
 
     /**

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -1198,25 +1198,20 @@ public class AppServices {
     }
 
     private static int[] signatureOptInCounts(PSBT psbt, Function<PSBTInput, Collection<ECKey>> keysFor) {
-        //Two ceilings, because the two costs are not the same. getVerifiedSignatures builds one message per distinct
-        //hash type and keeps it, so an input costs one message however many keys vouch for it, and verifying against
-        //a key is constant time after that. Messages are charged by what they hash and checks against a flat ceiling.
-        //Charging checks against the message budget was what left a 2 of 3 consolidation reading "not checked": it
-        //paid six times what it spends, and stopped a third of the way through.
+        //Two ceilings on the checks: what one input may ask, matching the one drongo applies to itself, and what a
+        //whole transaction may. Nothing here bounds the cost of a check beyond that, because opening any PSBT already
+        //verifies every partial signature in it with no bound at all, so a ceiling here would guard nothing.
         int inputCount = Math.max(1, psbt.getPsbtInputs().size());
-        long checkBudget = Math.min((long)MAX_INPUT_SIGNATURE_CHECKS * inputCount, MAX_SIGNATURE_CHECKS);
+        long checkBudget = Math.min((long)MAX_INPUT_SIGNATURE_CHECKS * inputCount, MAX_TRANSACTION_SIGNATURE_CHECKS);
 
         int optedIn = 0;
         int verified = 0;
         int total = 0;
         int checked = 0;
         for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
-            //Charged only for work that can happen. An input refused before any check runs costs nothing, or crafted
-            //inputs would spend the budget and silence every honest input after them.
-            //Refused before anything is parsed. Every other ceiling here counts signatures, and a witness may carry
-            //any number of pushes that are not signature shaped: each is still parsed and offered to the signature
-            //decoder, three times over, and a hundred inputs of a hundred thousand of them measured two and a half
-            //minutes. No spend needs anything like this many, and the count is already to hand.
+            //Refused before anything is parsed. The ceilings above count signatures, and a witness may carry any
+            //number of pushes that are not signature shaped: each is still parsed and offered to the signature
+            //decoder, three times over. No spend needs anything like this many, and the count is already to hand.
             if(pushCount(psbtInput) > MAX_INPUT_PUSHES) {
                 //Present and unreadable, which is the answer this owes for an input it will not look at
                 total += MAX_INPUT_PUSHES;
@@ -1247,6 +1242,8 @@ public class AppServices {
                 //Inside the guard: working out whether this input can be checked reads a script that can fail to read
                 boolean canCheck = wouldCheck > 0 && wouldCheck <= MAX_INPUT_SIGNATURE_CHECKS
                         && psbtInput.getUtxo() != null && psbtInput.getSigningScript() != null;
+                //Charged only for work that can happen. An input refused before any check runs costs nothing, or
+                //crafted inputs would spend the budget and silence every honest input after them.
                 if(!canCheck || checked + wouldCheck > checkBudget) {
                     keys = List.of();
                     wouldCheck = 0;
@@ -1279,12 +1276,14 @@ public class AppServices {
         return new int[] {optedIn, verified, total};
     }
 
-    /** What one input may ask for, matching drongo's own ceiling, and what a whole transaction may. */
+    /**
+     * What one input may ask for, matching the ceiling drongo applies to itself, and what a whole transaction may.
+     * Named apart from drongo's MAX_SIGNATURE_CHECKS, which is the per input one and is a different number.
+     */
     private static final int MAX_INPUT_SIGNATURE_CHECKS = 1024;
     //Measured at about 52 microseconds a verify, so this is a fifth of a second in the worst case a crafted PSBT can
     //arrange, on the thread that is drawing. It was 16384, which measured 855ms and froze the window.
-    private static final int MAX_SIGNATURE_CHECKS = 4096;
-
+    private static final int MAX_TRANSACTION_SIGNATURE_CHECKS = 4096;
 
     /**
      * Signatures that can be lifted out of this transaction and spent on the SHA256d chain.

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -567,11 +567,14 @@ public class HeadersController extends TransactionFormController implements Init
                     return null;
                 }
             });
-            //Read off the PSBT's own inputs, so a PSBT this wallet never built reports what it actually
-            //carries. The listener keeps it true when the type is changed here, since that change is
-            //written back to every input below.
-            updateOptInStatus(psbtSigHash);
-            sigHash.valueProperty().addListener((observable, oldValue, newValue) -> updateOptInStatus(newValue));
+            //Read off the PSBT's own inputs, so a PSBT this wallet never built reports what it actually carries
+            updateOptInStatus();
+            //Read again after the listener below has written the chosen type into every input. Reading it directly
+            //from here as well only answered for the inputs as they were before the change, and threw that away.
+            sigHash.valueProperty().addListener((observable, oldValue, newValue) -> Platform.runLater(this::refreshOptInStatus));
+            //The wallet is what vouches for the keys, and for a PSBT from elsewhere it arrives after the view is built
+            headersForm.signingWalletProperty().addListener((observable, oldValue, newValue) -> refreshOptInStatus());
+            signingWallet.valueProperty().addListener((observable, oldValue, newValue) -> refreshOptInStatus());
 
             sigHash.valueProperty().addListener((observable, oldValue, newValue) -> {
                 SigHash newBase = (newValue == null ? null : newValue.withoutUnified());
@@ -1055,7 +1058,7 @@ public class HeadersController extends TransactionFormController implements Init
      */
     private void refreshOptInStatus() {
         if(headersForm.getPsbt() != null) {
-            updateOptInStatus(sigHash.getValue());
+            updateOptInStatus();
         }
     }
 
@@ -1067,23 +1070,214 @@ public class HeadersController extends TransactionFormController implements Init
      * begin with. Recomputing this wallet's own decision here would answer a different question than the
      * one the transaction is being asked, and would put a second copy of that decision in the view.
      */
-    private void updateOptInStatus(SigHash psbtSigHash) {
-        //Counted off the signatures rather than taken from the declared hash type, because a transaction assembled
-        //from per-device PSBTs carries signatures the declaration does not describe
-        int[] counts = AppServices.signatureOptInCounts(headersForm.getPsbt());
-        int optedInSignatures = counts[0];
-        int signatures = counts[1];
+    private void updateOptInStatus() {
+        //Working this out can post a UnifiedSigHashScheduleEvent, which EventBus dispatches synchronously to this
+        //controller, so this can re-enter itself. SendController guards the same loop.
+        if(updatingOptInStatus) {
+            return;
+        }
 
-        //Before anything is signed there is nothing to count, so the declared type is what the transaction will be
-        boolean optedIn = signatures > 0 ? optedInSignatures > 0 : psbtSigHash != null && psbtSigHash.isUnified();
+        updatingOptInStatus = true;
+        try {
+            renderOptInStatus();
+        } finally {
+            updatingOptInStatus = false;
+        }
+    }
+
+    //Guards the re-entrancy described on updateOptInStatus above
+    private boolean updatingOptInStatus;
+
+    private void renderOptInStatus() {
+        //Said first, so a failure below leaves the labels saying nothing was checked rather than whatever they said
+        //a moment ago. Both writes land in the same pulse, so nothing flickers.
+        applyOptInStatus(uncheckedStatus());
+
+        try {
+            computeOptInStatus();
+        } catch(RuntimeException e) {
+            log.warn("Could not work out the replay protection status of this transaction", e);
+        }
+    }
+
+    /** What the labels say if working the answer out fails. */
+    private static OptInStatus uncheckedStatus() {
+        return new OptInStatus(OptInLevel.UNCHECKED, "Replay protection not checked",
+                "This transaction could not be checked for replay protection. Open it with the wallet that holds the keys, and until then treat it as carrying no replay protection.");
+    }
+
+    private void applyOptInStatus(OptInStatus status) {
+        //Everything built before anything is written, so the two labels cannot end up disagreeing with each other
+        List<Glyph> glyphs = List.of(glyphFor(status.level()), glyphFor(status.level()));
+        Tooltip tooltip = new Tooltip(status.detail());
+
+        signingWalletOptIn.setText(status.summary());
+        signingWalletOptIn.setGraphic(glyphs.get(0));
+        signingWalletOptIn.setTooltip(tooltip);
+
+        signaturesOptIn.setText(status.summary());
+        signaturesOptIn.setGraphic(glyphs.get(1));
+        signaturesOptIn.setTooltip(tooltip);
+    }
+
+    static Glyph glyphFor(OptInLevel level) {
+        return switch(level) {
+            case PROTECTED -> GlyphUtils.getSuccessGlyph();
+            case UNPROTECTED -> GlyphUtils.getWarningGlyph();
+            case UNCHECKED -> GlyphUtils.getQuestionGlyph();
+        };
+    }
+
+    private void computeOptInStatus() {
+        //Nothing to read. Said here rather than left to the null checks below, one of which is missing: a transaction
+        //that is not a PSBT reaches this from the sighash control being built, and has no signatures to count.
+        if(headersForm.getPsbt() == null) {
+            return;
+        }
+
+        //Only a key this wallet holds can vouch for a signature: every key an input carries was written by whoever
+        //wrote the input. The wallet chosen in the dropdown counts as much as one already bound to the form.
+        Wallet vouchingWallet = headersForm.getSigningWallet() != null ? headersForm.getSigningWallet() : signingWallet.getValue();
+        int[] counts = AppServices.signatureOptInCounts(headersForm.getPsbt(), vouchingWallet);
+        int optedInSignatures = counts[0];
+        int verifiedSignatures = counts[1];
+        int signatures = counts[2];
+
+        boolean everyInputDeclaresUnified = headersForm.getPsbt() != null
+                && !headersForm.getPsbt().getPsbtInputs().isEmpty()
+                && headersForm.getPsbt().getPsbtInputs().stream()
+                        .allMatch(input -> input.getSigHash() != null && input.getSigHash().isUnified());
+        boolean anyInputDeclaresUnified = headersForm.getPsbt() != null
+                && headersForm.getPsbt().getPsbtInputs().stream()
+                        .anyMatch(input -> input.getSigHash() != null && input.getSigHash().isUnified());
+
+        //The signers alone: a keystore mark is the only thing that strips a hash type the PSBT already declares. The
+        //chain qualifies the same opt-in and is reported separately, since its reasons explain nothing about signers.
+        UnifiedSigHashDecision decision = vouchingWallet == null ? null : AppServices.keystoreDecision(vouchingWallet);
+        //The first half is unreachable today, since optInStatus answers a transaction that does not declare the opt-in
+        //before it reads this. Kept because it is the right default if that ever changes: nothing declared is nothing
+        //for a signer to honour, and the alternative reads as "only if the signer opts in" over a legacy transaction.
+        boolean willBeHonoured = !everyInputDeclaresUnified || (decision != null && decision.isGuaranteed());
+
+        //What the signers leave open, then what the chain does, in the order the send screen gives them. The caveat
+        //comes from AppServices so it arrives with the marked signers named; the chain's sentences need no wallet.
+        boolean nothingSigned = nothingSigned(headersForm.getPsbt());
+
+        List<String> qualifications = new ArrayList<>();
+        if(nothingSigned) {
+            String signerCaveat = vouchingWallet == null ? null : AppServices.keystoreCaveat(vouchingWallet);
+            if(signerCaveat != null) {
+                qualifications.add(signerCaveat);
+            }
+            qualifications.addAll(AppServices.chainQualifications());
+        }
+
+        OptInStatus status = optInStatus(everyInputDeclaresUnified, anyInputDeclaresUnified, willBeHonoured, nothingSigned, decision, qualifications,
+                optedInSignatures, verifiedSignatures, signatures,
+                AppServices.liftableSignatureCount(headersForm.getPsbt()));
+
+        applyOptInStatus(status);
+    }
+
+    /**
+     * Whether anything has signed, which is a fact about the PSBT and not about how many pushes look like
+     * signatures: a finalised input carrying nothing signature shaped counts zero, and the label then republished
+     * the file's own declaration as a settled promise. Taproot script path signatures count as much as any other.
+     */
+    static boolean nothingSigned(PSBT psbt) {
+        return psbt.getPsbtInputs().stream()
+                .noneMatch(input -> input.isFinalized() || !input.getPartialSignatures().isEmpty()
+                        || input.getTapKeyPathSignature() != null || !input.getTapScriptSignatures().isEmpty());
+    }
+
+    /**
+     * The three things a transaction can be, which are not two.
+     *
+     * One opted-in signature anywhere protects the transaction, so saying it has none is a claim about every
+     * signature in it. Where one could not be checked, that claim cannot be made either way.
+     */
+    enum OptInLevel {
+        PROTECTED, UNPROTECTED, UNCHECKED
+    }
+
+    /** What the labels say, worked out apart from them so it can be read back and checked. */
+    record OptInStatus(OptInLevel level, String summary, String detail) {
+        boolean optedIn() {
+            return level == OptInLevel.PROTECTED;
+        }
+    }
+
+    static OptInStatus optInStatus(boolean everyInputDeclaresUnified, boolean anyInputDeclaresUnified,
+                                   boolean willBeHonoured, boolean nothingSigned, UnifiedSigHashDecision decision,
+                                   List<String> qualifications, int optedInSignatures, int verifiedSignatures,
+                                   int signatures, int liftable) {
+        //Every input, not the first that declares anything: a PSBT can declare the opt-in on an input this wallet
+        //will never sign and the old type on the ones it will
+        boolean optedIn = nothingSigned ? everyInputDeclaresUnified : optedInSignatures > 0;
         boolean everySignature = signatures > 0 && optedInSignatures == signatures;
 
-        for(Label label : List.of(signingWalletOptIn, signaturesOptIn)) {
-            label.setText(UnifiedSigHashDecision.summaryFor(optedIn));
-            label.setGraphic(optedIn ? GlyphUtils.getSuccessGlyph() : GlyphUtils.getWarningGlyph());
-            label.setTooltip(new Tooltip(optedInStatusDetail(optedIn, everySignature, optedInSignatures, signatures,
-                    AppServices.liftableSignatureCount(headersForm.getPsbt()))));
+        //Something signed, yet nothing reads as a signature. The declaration is not evidence: the file wrote it.
+        if(!nothingSigned && signatures == 0) {
+            return new OptInStatus(OptInLevel.UNCHECKED, "Replay protection not checked",
+                    "This transaction carries signatures that could not be read, so nothing here says whether any of them opts in. Open it with the wallet that holds the keys, and until then treat it as carrying no replay protection.");
         }
+
+        //Nothing signed, so what the inputs declare is intent, and a PSBT from elsewhere writes its own
+        if(nothingSigned) {
+            //Some ask for the opt-in and some do not, which is any externally assembled transaction: a co-signer's
+            //PSBT, a payjoin proposal, a coinjoin. One opted-in signature anywhere protects the whole transaction, so
+            //this is not the settled negative the count of declarations alone would make it.
+            if(anyInputDeclaresUnified && !everyInputDeclaresUnified) {
+                return new OptInStatus(OptInLevel.UNCHECKED, "Replay protection depends on which inputs are signed",
+                        "Some of these inputs ask for the opt-in and some do not. One signature that opts in anywhere protects the whole transaction, so whether this one ends up protected depends on which of these inputs are signed, and by a signer that opts in.");
+            }
+
+            //A settled negative takes the warning mark; a declaration a signer may not honour takes the question mark
+            if(!optedIn) {
+                return new OptInStatus(OptInLevel.UNPROTECTED, "Will not be replay protected",
+                        optedInStatusDetail(false, everySignature, optedInSignatures, verifiedSignatures, signatures, liftable));
+            }
+
+            String detail = willBeHonoured
+                    ? optedInStatusDetail(true, everySignature, optedInSignatures, verifiedSignatures, signatures, liftable)
+                    : conditionalDetail(decision);
+
+            //The chain's own sentences, after the answer about the signers rather than spliced into it
+            for(String qualification : qualifications) {
+                detail += System.lineSeparator() + System.lineSeparator() + qualification;
+            }
+
+            return new OptInStatus(OptInLevel.UNCHECKED,
+                    willBeHonoured ? "Will be replay protected" : "Replay protected only if the signer opts in", detail);
+        }
+
+        OptInLevel level = optedIn ? OptInLevel.PROTECTED
+                : (signatures > verifiedSignatures ? OptInLevel.UNCHECKED : OptInLevel.UNPROTECTED);
+
+        return new OptInStatus(level, level == OptInLevel.UNCHECKED ? "Replay protection not checked"
+                : UnifiedSigHashDecision.summaryFor(optedIn),
+                optedInStatusDetail(optedIn, everySignature, optedInSignatures, verifiedSignatures, signatures, liftable));
+    }
+
+    /**
+     * Why a declared opt-in might not survive what signs it, in the decision's own words.
+     *
+     * A decision that would not opt in carries the reason. A partially marked quorum carries none, only a caveat,
+     * and reading the reason for it printed the literal word null in the ordinary one marked signer multisig.
+     */
+    private static String conditionalDetail(UnifiedSigHashDecision decision) {
+        String sentence = "These inputs ask for the opt-in, and whether it survives depends on what signs them";
+        if(decision == null) {
+            return sentence + ", which no open wallet here can answer for. Open this transaction with the wallet that holds the keys.";
+        }
+
+        if(decision.getReason() != null) {
+            return sentence + ", because " + decision.getReason() + "."
+                    + (decision.getRemedy() == null ? "" : System.lineSeparator() + System.lineSeparator() + decision.getRemedy());
+        }
+
+        //The caveat itself is appended by the caller, which has the wallet and so can name the marked signers
+        return sentence + ".";
     }
 
     /**
@@ -1091,29 +1285,57 @@ public class HeadersController extends TransactionFormController implements Init
      * to the transaction and takes one opted-in signature anywhere in it. The second belongs to each signature. Saying
      * only "protected" over a mixed witness would claim the second for signers that did not opt in.
      */
-    private static String optedInStatusDetail(boolean optedIn, boolean everySignature, int optedInSignatures, int signatures, int liftable) {
+    private static String optedInStatusDetail(boolean optedIn, boolean everySignature, int optedInSignatures, int verifiedSignatures, int signatures, int liftable) {
         if(!optedIn) {
-            return "These signatures are made the way they always have been. They carry no replay protection.";
+            //Three states, not two: every signature checked, none checkable, or some of each. None checkable must not
+            //imply it looked, and neither of those two says the transaction is unprotected.
+            if(verifiedSignatures == 0 && signatures > 0) {
+                return "None of these signatures could be checked against a key this wallet holds, so this cannot say whether any of them opts in. Open this transaction with the wallet that holds the keys to find out, and until then treat it as carrying no replay protection.";
+            }
+
+            if(verifiedSignatures < signatures) {
+                return "Not all of these signatures could be checked. None of the ones that could opts in, and one signature that opts in anywhere is enough, so this cannot say whether the transaction is protected. Until it can be, treat it as carrying no replay protection.";
+            }
+
+            return signatures == 0
+                    ? "These signatures will be made the way they always have been. They will carry no replay protection."
+                    : "These signatures are made the way they always have been. They carry no replay protection.";
         }
 
-        if(everySignature || signatures == 0) {
+        if(signatures == 0) {
+            //Nothing is signed yet, so this describes what the transaction will be rather than what it is
+            return "These signatures will not be valid under the pre-fork rules, so this transaction will not be replayable onto the SHA256d chain, and each signature will commit to the amount it spends.";
+        }
+
+        if(everySignature) {
             //"the amount it spends" rather than "the amounts they spend": an Anyone Can Pay signature commits to its
             //own input's amount and no other, so the blanket claim was not true of one.
             return "These signatures are not valid under the pre-fork rules, so they cannot be replayed onto the SHA256d chain, and each commits to the amount it spends.";
         }
 
+        int others = signatures - optedInSignatures;
         String detail = "This transaction cannot be replayed onto the SHA256d chain: one signature that opts in is enough, and "
-                + optedInSignatures + " of " + signatures + " do."
+                + optedInSignatures + " of " + signatures + (optedInSignatures == 1 ? " does." : " do.")
                 + System.lineSeparator() + System.lineSeparator()
-                + "The other " + (signatures - optedInSignatures) + " were made the way they always have been, so those signers were shown the amounts by this computer rather than committing to them.";
+                //Hedged only where something could not be checked, or this tells a signer their own signature was unreadable
+                + (verifiedSignatures < signatures
+                        ? (others == 1 ? "The other one could not be confirmed as opting in, so treat it as made the old way: that signer was"
+                                       : "The other " + others + " could not be confirmed as opting in, so treat them as made the old way: those signers were")
+                            + " shown the amounts by this computer rather than committing to them."
+                        : (others == 1 ? "The other one was made the old way, so that signer was"
+                                       : "The other " + others + " were made the way they always have been, so those signers were")
+                            + " shown the amounts by this computer rather than committing to them.");
 
         //A legacy ANYONECANPAY signature commits only to its own input and to the outputs, so unlike the other legacy
         //types it survives being lifted into a transaction that drops the inputs which opted in. The transaction is
         //protected either way, so this is the one case where the headline is true and still not the whole answer.
         if(liftable > 0) {
+            //Read from every push that looks like a signature, because this reports a risk rather than a finding
+            String signs = verifiedSignatures < signatures ? "may sign" : "signs";
+            String sign = verifiedSignatures < signatures ? "may sign" : "sign";
             detail += System.lineSeparator() + System.lineSeparator()
-                    + (liftable == 1 ? "One of those signs Anyone Can Pay, so it commits only to its own input and to the outputs. That input alone can be lifted into another transaction and spent on the SHA256d chain, paying these same outputs."
-                                     : liftable + " of those sign Anyone Can Pay, so each commits only to its own input and to the outputs. Those inputs can be lifted into another transaction and spent on the SHA256d chain, paying these same outputs.")
+                    + (liftable == 1 ? "One of those " + signs + " Anyone Can Pay, so it commits only to its own input and to the outputs. That input alone can be lifted into another transaction and spent on the SHA256d chain, paying these same outputs."
+                                     : liftable + " of those " + sign + " Anyone Can Pay, so each commits only to its own input and to the outputs. Those inputs can be lifted into another transaction and spent on the SHA256d chain, paying these same outputs.")
                     + " Have those signers opt in too, or sign the whole transaction with All, to close that.";
         }
 
@@ -1369,8 +1591,10 @@ public class HeadersController extends TransactionFormController implements Init
                 EventManager.get().post(new TransactionOutputsChangedEvent(headersForm.getTransaction()));
             }
             unencryptedWallet.sign(signingNodes);
-            updateSignedKeystores(headersForm.getSigningWallet());
+            //Before anything that can throw: a partial sign then a failure would leave the label describing the
+            //transaction as it was before this wallet signed
             refreshOptInStatus();
+            updateSignedKeystores(headersForm.getSigningWallet());
         } catch(Exception e) {
             log.warn("Failed to Sign", e);
             AppServices.showErrorDialog("Failed to Sign", e.getMessage());
@@ -1423,7 +1647,10 @@ public class HeadersController extends TransactionFormController implements Init
             try {
                 headersForm.getSigningWallet().finalise(headersForm.getPsbt());
                 EventManager.get().post(new PSBTFinalizedEvent(headersForm.getPsbt()));
-            } catch(IllegalArgumentException e) {
+            } catch(RuntimeException e) {
+                //Not only IllegalArgumentException: an external multisig script whose keys are not sorted, or that
+                //repeats one, fails the reconstruction check and leaves as a ProtocolException, which went past this
+                //and out of the button handler with nothing shown. Pre-existing, and reachable from a PSBT.
                 AppServices.showErrorDialog("Cannot finalize PSBT", e.getMessage());
                 throw e;
             }
@@ -1704,6 +1931,9 @@ public class HeadersController extends TransactionFormController implements Init
     @Subscribe
     public void transactionChanged(TransactionChangedEvent event) {
         if(headersForm.getTransaction().equals(event.getTransaction())) {
+            //An edit to the transaction is an edit to what every signature on it was made over, so whatever was read
+            //about them describes a transaction that no longer exists
+            refreshOptInStatus();
             updateTxId();
             updateEditable(headersForm.isEditable());
             registerPayjoinURI();
@@ -1758,6 +1988,12 @@ public class HeadersController extends TransactionFormController implements Init
             signaturesForm.setVisible(true);
             broadcastButtonBox.setVisible(true);
             viewFinalButton.setDisable(true);
+
+            //A transaction that is not a PSBT has nothing for this to read, and an empty field beside the label is worse
+            //than one saying it was not checked
+            if(headersForm.getPsbt() == null) {
+                applyOptInStatus(uncheckedStatus());
+            }
 
             if(headersForm.getSigningWallet() == null) {
                 for(Wallet wallet : AppServices.get().getOpenWallets().keySet()) {
@@ -1894,31 +2130,69 @@ public class HeadersController extends TransactionFormController implements Init
             } else {
                 signButtonBox.setVisible(true);
                 event.getPsbt().addKeyPathInformation(event.getSigningWallet());
+                //Adding the key paths is what lets this wallet recognise inputs beyond its derived range, so the
+                //reading taken before it can be the poorer of the two
+                refreshOptInStatus();
             }
         }
+    }
+
+    /**
+     * The unsigned reading rests on the keystore marks and on the chain, neither of which this controller owns, so
+     * it goes stale the moment either moves.
+     */
+    @Subscribe
+    public void keystoreUnifiedSigHashChanged(KeystoreUnifiedSigHashChangedEvent event) {
+        if(!Platform.isFxApplicationThread()) {
+            Platform.runLater(() -> keystoreUnifiedSigHashChanged(event));
+            return;
+        }
+
+        refreshOptInStatus();
+    }
+
+    @Subscribe
+    public void unifiedSigHashSchedule(UnifiedSigHashScheduleEvent event) {
+        //EventBus dispatches on the thread that posted, which here is whichever thread read a schedule off a node
+        if(!Platform.isFxApplicationThread()) {
+            Platform.runLater(() -> unifiedSigHashSchedule(event));
+            return;
+        }
+
+        refreshOptInStatus();
     }
 
     @Subscribe
     public void psbtCombined(PSBTCombinedEvent event) {
         if(event.getPsbt().equals(headersForm.getPsbt())) {
+            //Read first: the event bus swallows a subscriber's exception, so anything ahead of this that threw would
+            //leave the label describing the transaction as it was before those signatures arrived
+            refreshOptInStatus();
+
             learnSilentPaymentAddresses(headersForm.getSigningWallet(), headersForm.getPsbt());
             if(headersForm.getSigningWallet() != null) {
                 updateSignedKeystores(headersForm.getSigningWallet());
             } else if(headersForm.getPsbt().isSigned()) {
                 Wallet signedWallet = new FinalizingPSBTWallet(headersForm.getPsbt());
                 headersForm.setSigningWallet(signedWallet);
-                finalizePSBT();
+                try {
+                    finalizePSBT();
+                } finally {
+                    //Finalising mutates input by input, so a failure partway has already changed what is on screen
+                    refreshOptInStatus();
+                }
                 EventManager.get().post(new FinalizeTransactionEvent(headersForm.getPsbt(), signedWallet));
             }
-
-            //A combine is where a cosigner's signatures arrive, so it is where the count this reports changes
-            refreshOptInStatus();
         }
     }
 
     @Subscribe
     public void psbtFinalized(PSBTFinalizedEvent event) {
         if(event.getPsbt().equals(headersForm.getPsbt())) {
+            //First, before anything that could throw. Finalising can drop a signature: a quorum takes the first
+            //signatures in key order up to its threshold, so the opted-in one can be the one left out.
+            refreshOptInStatus();
+
             learnSilentPaymentAddresses(headersForm.getSigningWallet(), headersForm.getPsbt());
             if(headersForm.getSigningWallet() != null) {
                 updateSignedKeystores(headersForm.getSigningWallet());
@@ -1949,8 +2223,15 @@ public class HeadersController extends TransactionFormController implements Init
     @Subscribe
     public void keystoreSigned(KeystoreSignedEvent event) {
         if(headersForm.getSignedKeystores().contains(event.getKeystore()) && headersForm.getPsbt() != null) {
-            //Attempt to finalize PSBT - will do nothing if all inputs are not signed
-            finalizePSBT();
+            //Finalising does nothing below the threshold and mutates input by input above it, so read either way
+            refreshOptInStatus();
+
+            try {
+                //Attempt to finalize PSBT - will do nothing if all inputs are not signed
+                finalizePSBT();
+            } finally {
+                refreshOptInStatus();
+            }
         }
     }
 
@@ -1964,6 +2245,8 @@ public class HeadersController extends TransactionFormController implements Init
     @Subscribe
     public void transactionExtracted(TransactionExtractedEvent event) {
         if(event.getPsbt().equals(headersForm.getPsbt())) {
+            //The final transaction is what will be broadcast, so this is the last chance to disagree with the label
+            refreshOptInStatus();
             updateTxId();
             updateType();
             updateSize();
@@ -2047,6 +2330,12 @@ public class HeadersController extends TransactionFormController implements Init
 
     @Subscribe
     public void newBlock(NewBlockEvent event) {
+        //The chain bears on the unsigned reading alone: once something has signed the answer comes off the signatures.
+        //Read through AppServices, so it lags a block if Guava ever stops dispatching in registration order.
+        if(headersForm.getPsbt() != null && nothingSigned(headersForm.getPsbt())) {
+            refreshOptInStatus();
+        }
+
         if(headersForm.getBlockTransaction() != null) {
             updateBlockchainForm(headersForm.getBlockTransaction(), event.getHeight());
         }
@@ -2058,6 +2347,8 @@ public class HeadersController extends TransactionFormController implements Init
     @Subscribe
     public void psbtReordered(PSBTReorderedEvent event) {
         if(event.getPsbt().equals(headersForm.getPsbt())) {
+            //Reordering changes the message every signature commits to, the same as any other edit
+            refreshOptInStatus();
             updateTxId();
             headersForm.setWalletTransaction(getWalletTransaction(headersForm.getInputTransactions()));
             registerPayjoinURI();

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1129,6 +1129,24 @@ public class SendController extends WalletFormController implements Initializabl
             return;
         }
 
+        //Said before anything that could fail, so a failure leaves this saying nothing was worked out rather than
+        //whatever it said about an earlier transaction
+        optInStatus.setVisible(true);
+        optInStatus.setText("Replay protection not worked out");
+        optInStatus.setGraphic(GlyphUtils.getQuestionGlyph());
+        optInStatus.setTooltip(new Tooltip("This transaction could not be checked for replay protection."));
+        optInStatus.getStyleClass().removeAll("actionable");
+        optInStatus.setCursor(Cursor.DEFAULT);
+        optInStatus.setOnMouseClicked(null);
+
+        try {
+            renderKnownOptInStatus(walletTransaction);
+        } catch(RuntimeException e) {
+            log.warn("Could not work out the replay protection status of this transaction", e);
+        }
+    }
+
+    private void renderKnownOptInStatus(WalletTransaction walletTransaction) {
         AppServices.UnifiedSigHashStatus status = AppServices.getUnifiedSigHashStatus(walletTransaction.getWallet());
         UnifiedSigHashDecision decision = status.decision();
         optInStatus.setVisible(true);
@@ -1150,24 +1168,43 @@ public class SendController extends WalletFormController implements Initializabl
             optInStatus.setOnMouseClicked(null);
         }
 
-        StringBuilder detail = new StringBuilder();
-        if(decision.isOptedIn()) {
-            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed onto the SHA256d chain, and each commits to the amount it spends.");
-            //Every caveat that applies, not only the one the headline came from: on an Electrum connection a
-            //partially marked multisig has two, and the one the headline dropped is the actionable one
-            for(String caveat : status.caveats()) {
-                detail.append(System.lineSeparator()).append(System.lineSeparator()).append(caveat);
-            }
-        } else {
-            detail.append("These signatures will be made the way they always have been, because ").append(decision.getReason()).append(".");
-            if(decision.getRemedy() != null) {
-                detail.append(System.lineSeparator()).append(System.lineSeparator()).append(decision.getRemedy());
-            }
-        }
-
-        Tooltip tooltip = new Tooltip(detail.toString());
+        Tooltip tooltip = new Tooltip(optInDetail(decision, status.caveats()));
         tooltip.setShowDuration(Duration.INDEFINITE);
         optInStatus.setTooltip(tooltip);
+    }
+
+    /**
+     * What the send screen says these signatures will do, worked out apart from the label so every decision can be
+     * checked. The transaction view had this shape inline and printed the word null for a decision with no reason.
+     */
+    static String optInDetail(UnifiedSigHashDecision decision, List<String> caveats) {
+        StringBuilder detail = new StringBuilder();
+
+        if(decision.isOptedIn()) {
+            //Committing to the spent amounts belongs to each signature, not to the transaction, so it can only be
+            //claimed where every signature will opt in. A partially marked quorum is protected the moment one marked
+            //signer signs, and the unmarked ones still commit to nothing.
+            detail.append(decision.isGuaranteed()
+                    ? "These signatures are not valid under the pre-fork rules, so they cannot be replayed onto the SHA256d chain, and each commits to the amount it spends."
+                    : "This transaction cannot be replayed onto the SHA256d chain if one of the marked signers is among those that sign, because one signature that opts in is enough. Only the signers that opt in commit to the amounts they spend; the others are shown those amounts by this computer.");
+        } else if(decision.getReason() != null) {
+            detail.append("These signatures will be made the way they always have been, because ").append(decision.getReason()).append(".");
+        } else {
+            //No decision declines without a reason today; saying less beats saying the word null
+            detail.append("These signatures will be made the way they always have been.");
+        }
+
+        //Every caveat that applies, not only the one the headline came from: on an Electrum connection a partially
+        //marked multisig has two, and the one the headline dropped is the actionable one
+        for(String caveat : caveats) {
+            detail.append(System.lineSeparator()).append(System.lineSeparator()).append(caveat);
+        }
+
+        if(!decision.isOptedIn() && decision.getRemedy() != null) {
+            detail.append(System.lineSeparator()).append(System.lineSeparator()).append(decision.getRemedy());
+        }
+
+        return detail.toString();
     }
 
     /**

--- a/src/main/resources/com/sparrowwallet/sparrow/general.css
+++ b/src/main/resources/com/sparrowwallet/sparrow/general.css
@@ -227,6 +227,14 @@
     -fx-text-fill: rgb(238, 210, 2);
 }
 
+/* An answer that could not be worked out asks for the same attention as one that came back bad: the shape says which
+   of the two it is, and leaving it in body text made the least readable of the three states the one carrying a
+   warning. send.css styles this class under #transactionDiagram, which nothing there carries today and which would
+   win anyway on specificity. */
+.question-icon {
+    -fx-text-fill: rgb(238, 210, 2);
+}
+
 .root .header-panel {
     -fx-background-color: -fx-box-border, derive(-fx-background, 10%);
 }

--- a/src/test/java/com/sparrowwallet/sparrow/ChainQualificationsTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/ChainQualificationsTest.java
@@ -1,0 +1,94 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.protocol.BlockHeader;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * What the chain has to say about a transaction that already declares the opt-in.
+ *
+ * The transaction view used to fold this into the sentence about what signs the inputs, which produced
+ * "whether it survives depends on what signs them, because the fork is not active on this chain yet": a reason that
+ * explains nothing in the sentence carrying it. Only the keystore marks decide whether a declared hash type survives,
+ * so the chain answers separately or not at all. It must still answer, because dropping it was how the transaction
+ * view came to make a stronger claim than the send screen on every Electrum connection.
+ */
+public class ChainQualificationsTest {
+    /**
+     * Every decision the chain can reach, since a decision arriving here with nothing to say is how the neighbouring
+     * sentence came to print the word null.
+     */
+    @Test
+    public void every_decision_reads_as_a_sentence() {
+        for(UnifiedSigHashDecision decision : UnifiedSigHashDecision.values()) {
+            for(String qualification : AppServices.chainQualifications(decision)) {
+                Assertions.assertFalse(qualification.contains("null"), decision + ": " + qualification);
+                Assertions.assertTrue(qualification.endsWith("."), decision + ": " + qualification);
+                Assertions.assertTrue(Character.isUpperCase(qualification.charAt(0)), decision + ": " + qualification);
+            }
+        }
+    }
+
+    /**
+     * A chain that would not opt in says so as its own statement. "Separately" is load bearing: the sentence before it
+     * says what the signatures will be, and without it the two read as one answer contradicting itself.
+     */
+    @Test
+    public void a_chain_that_would_not_opt_in_says_so_apart_from_the_signers() {
+        List<String> qualifications = AppServices.chainQualifications(UnifiedSigHashDecision.BEFORE_ACTIVATION_HEIGHT);
+
+        Assertions.assertEquals("Separately, the chain has not reached the activation height, so this wallet would not "
+                + "itself opt in as things stand.", qualifications.get(0));
+        Assertions.assertFalse(qualifications.get(0).contains("signs them"),
+                "the chain explains nothing about what signs the inputs, which is why it is stated apart from them");
+    }
+
+    /**
+     * The Electrum case, and the reason this is plumbed through at all. No Electrum server reports an activation
+     * height, so the cross check that would catch a stale build cannot run, and the transaction view said nothing
+     * about it while the send screen did.
+     */
+    @Test
+    public void an_uncorroborated_opt_in_keeps_its_caveat() {
+        List<String> qualifications = AppServices.chainQualifications(UnifiedSigHashDecision.OPTED_IN_UNCORROBORATED);
+
+        Assertions.assertEquals(1, qualifications.size());
+        Assertions.assertEquals(UnifiedSigHashDecision.OPTED_IN_UNCORROBORATED.getCaveat(), qualifications.get(0));
+    }
+
+    /** A chain that has activated and can be corroborated has nothing to add. */
+    @Test
+    public void a_settled_chain_says_nothing() {
+        Assertions.assertEquals(List.of(), AppServices.chainQualifications(UnifiedSigHashDecision.OPTED_IN));
+    }
+
+    /**
+     * And the same through the real reading of the chain rather than a decision handed in, so the wiring between the
+     * announced tip and these sentences is checked and not assumed.
+     */
+    @Test
+    public void the_announced_tip_reaches_these_sentences() {
+        Network previousNetwork = Network.get();
+        Network.set(Network.MAINNET);
+        ChainTip previous = AppServices.getAnnouncedTip();
+        try {
+            AppServices.setAnnouncedTip(null);
+            Assertions.assertEquals(AppServices.chainQualifications(UnifiedSigHashDecision.CHAIN_UNSEEN),
+                    AppServices.chainQualifications(),
+                    "with no tip announced the chain has not been seen, and that is what the label has to say");
+
+            //A pre-fork header, which is a chain that has not activated whatever height it claims
+            BlockHeader preFork = new BlockHeader(1, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH, null, 0, 0x207fffffL, 0);
+            AppServices.setAnnouncedTip(new ChainTip(1, preFork));
+            Assertions.assertEquals(AppServices.chainQualifications(UnifiedSigHashDecision.CHAIN_NOT_ACTIVATED),
+                    AppServices.chainQualifications());
+        } finally {
+            AppServices.setAnnouncedTip(previous);
+            Network.set(previousNetwork);
+        }
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/MixedWitnessCombineTest.java
@@ -27,8 +27,8 @@ public class MixedWitnessCombineTest {
         Network.set(Network.MAINNET);
         PSBT psbt = mixedWitnessPsbt(SigHash.UNIFIED_ALL, SigHash.ALL);
 
-        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt)[1], "both keys must have signed");
-        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt)[0], "one of them opted in");
+        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt, fixtureWallet)[2], "both keys must have signed");
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt, fixtureWallet)[0], "one of them opted in");
 
         //The combine path and the parse path both run this. It must not reject a witness the finalise
         //path is happy to build.
@@ -40,7 +40,7 @@ public class MixedWitnessCombineTest {
         Network.set(Network.MAINNET);
         PSBT psbt = mixedWitnessPsbt(SigHash.ALL, SigHash.UNIFIED_ALL);
 
-        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt)[0], "one of them opted in");
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt, fixtureWallet)[0], "one of them opted in");
         psbt.verifySignatures();
     }
 
@@ -98,7 +98,7 @@ public class MixedWitnessCombineTest {
         PSBT psbt = mixedWitnessPsbt(SigHash.ALL, SigHash.NONE);
 
         //Both keys signed, over two different output types
-        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt)[1]);
+        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt, fixtureWallet)[2]);
 
         Assertions.assertThrows(PSBTSignatureException.class, psbt::verifySignatures,
                 "a signature over a type the input never asked for must not verify");
@@ -209,9 +209,13 @@ public class MixedWitnessCombineTest {
         return psbt;
     }
 
+    /** The wallet the last fixture was built from, which is what vouches for the keys when counting. */
+    private Wallet fixtureWallet;
+
     /** A real 2-of-2 P2WSH signed once per hash type, the way per-device PSBTs combine. */
     private PSBT mixedWitnessPsbt(SigHash firstType, SigHash secondType) throws Exception {
         Wallet wallet = twoOfTwo();
+        fixtureWallet = wallet;
         PSBT psbt = psbtFor(wallet);
         PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
 

--- a/src/test/java/com/sparrowwallet/sparrow/SignatureOptInCountTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/SignatureOptInCountTest.java
@@ -29,4 +29,648 @@ import java.util.List;
  */
 public class SignatureOptInCountTest {
     private static final String PRIVATE_KEY = "11".repeat(32);
-    private static final long VALUE = 100_000_000L;}
+    private static final long VALUE = 100_000_000L;
+    /** MAX_INPUT_SIGNATURE_CHECKS in AppServices, which is what refuses an input before any check runs. */
+    private static final int MAX_INPUT_PUSHES = 1024;
+
+    private ECKey key() {
+        return ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY));
+    }
+
+    private PSBT signed(byte sigHashType) {
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+        psbtInput.setSigHash(SigHash.fromByte(sigHashType));
+        psbtInput.sign(outputKey);
+
+        return psbt;
+    }
+
+    /** A 65 byte push ending in a byte that reads as an opt-in, which a taproot control block is half the time. */
+    /** What a caller vouches for here: the one key this fixture signs with. */
+    private List<ECKey> trusted() {
+        return List.of(ECKey.fromPublicOnly(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key())));
+    }
+
+    private byte[] junk() {
+        byte[] push = new byte[65];
+        Arrays.fill(push, (byte)0x11);
+        push[64] = (byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue());
+        return push;
+    }
+
+    private void finaliseWith(PSBT psbt, byte[]... extraPushes) {
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        TransactionSignature signature = psbtInput.getPartialSignature(ECKey.fromPublicOnly(outputKey));
+
+        List<byte[]> pushes = new ArrayList<>();
+        pushes.add(signature.encodeToBitcoin());
+        pushes.add(outputKey.getPubKey());
+        pushes.addAll(Arrays.asList(extraPushes));
+        psbtInput.setFinalScriptWitness(new TransactionWitness(null, pushes));
+    }
+
+    @Test
+    public void a_signature_that_opts_in_is_counted() {
+        PSBT psbt = signed((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue()));
+
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt, trusted())[0]);
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt, trusted())[2]);
+    }
+
+    @Test
+    public void one_that_does_not_is_not() {
+        PSBT psbt = signed(SigHash.ALL.byteValue());
+
+        Assertions.assertEquals(0, AppServices.signatureOptInCounts(psbt, trusted())[0]);
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt, trusted())[2]);
+    }
+
+    /**
+     * The case this is here for. The witness carries a real signature that does not opt in, next to a push that is not a
+     * signature and ends in a byte that says it does. Counted without checking, this transaction reports itself replay
+     * protected when nothing about it is.
+     */
+    @Test
+    public void a_push_that_only_looks_like_a_signature_cannot_claim_the_protection() {
+        PSBT psbt = signed(SigHash.ALL.byteValue());
+        finaliseWith(psbt, junk());
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(0, counts[0], "a push that verifies against nothing claimed the protection");
+        Assertions.assertEquals(2, counts[2], "the denominator counts what is present, so the claim reads as incomplete");
+    }
+
+    /**
+     * And the other direction: a real opt-in beside the same push is still reported, so the check refuses the forgery
+     * rather than refusing everything.
+     */
+    @Test
+    public void a_real_opt_in_beside_it_is_still_counted() {
+        PSBT psbt = signed((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue()));
+        finaliseWith(psbt, junk());
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(1, counts[0]);
+        Assertions.assertEquals(2, counts[2], "the push is still counted, so one of two opted in rather than all of them");
+    }
+
+    /**
+     * The two reasons a transaction does not opt in, which the numbers have to keep apart because they read very
+     * differently to someone deciding whether to broadcast.
+     *
+     * A stock signer produces a signature this wallet checks and finds is simply the old kind. A push that is not a
+     * signature is something this wallet cannot check at all. Reporting the second as though it were the first would
+     * tell a user their own signature could not be confirmed, which is both wrong and alarming.
+     */
+    @Test
+    public void a_signature_checked_and_found_legacy_is_not_the_same_as_one_that_could_not_be_checked() {
+        int[] stockSigner = AppServices.signatureOptInCounts(signed(SigHash.ALL.byteValue()), trusted());
+        Assertions.assertArrayEquals(new int[] {0, 1, 1}, stockSigner,
+                "the signature was checked, so nothing here is unknown");
+
+        PSBT withJunk = signed(SigHash.ALL.byteValue());
+        finaliseWith(withJunk, junk());
+        int[] somethingUnreadable = AppServices.signatureOptInCounts(withJunk, trusted());
+        Assertions.assertArrayEquals(new int[] {0, 1, 2}, somethingUnreadable,
+                "one of the two could not be checked, and the count has to show that");
+    }
+
+    /** A transaction of many inputs, each signed for real by the one key this fixture vouches for. */
+    private PSBT manyInputs(int inputs, byte sigHashType) {
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i < inputs; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        //Every spent output first: the unified message commits to all of them, so none can be signed until all are set
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            psbtInput.setSigHash(SigHash.fromByte(sigHashType));
+        }
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.sign(outputKey);
+        }
+
+        return psbt;
+    }
+
+    /**
+     * An ordinary transaction of many inputs is checked to the end. A ceiling meant to bound a hostile transaction must
+     * not ration an honest one, and two hundred single signature inputs is a consolidation someone really sends.
+     */
+    @Test
+    public void every_input_of_an_ordinary_transaction_is_checked() {
+        byte unifiedAll = (byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue());
+        PSBT psbt = manyInputs(200, unifiedAll);
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(200, counts[0], "every input opted in and every one should have been checked");
+        Assertions.assertEquals(200, counts[1]);
+        Assertions.assertEquals(200, counts[2]);
+    }
+
+    /**
+     * Inputs that cannot be checked must cost the transaction nothing.
+     *
+     * Each is refused before a single check runs, because it carries more pushes than one input may ask for. If the
+     * budget were charged for that refused work, enough of them would exhaust it and the honest input at the end would
+     * go unchecked, which suppresses exactly the signal this reports. The count of crafted inputs here is chosen so
+     * that charging for them would overrun the budget and skipping them does not.
+     */
+    @Test
+    public void inputs_that_cannot_be_checked_do_not_silence_the_honest_one() {
+        byte unifiedAll = (byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue());
+        //Chosen so that charging for the crafted inputs would consume the transaction's budget exactly, leaving the
+        //honest input nothing: nine inputs allow 9216 checks, and eight refused inputs of 1152 pushes come to 9216.
+        int crafted = 8;
+        int pushesEach = 1152;
+
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i <= crafted; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            psbtInput.setSigHash(SigHash.fromByte(unifiedAll));
+        }
+
+        //The honest input is last, so anything the crafted ones consume is consumed before it is reached
+        PSBTInput honest = psbt.getPsbtInputs().get(crafted);
+        Assertions.assertTrue(honest.sign(outputKey), "the honest input must be signed");
+
+        for(int i = 0; i < crafted; i++) {
+            List<byte[]> pushes = new ArrayList<>();
+            for(int j = 0; j < pushesEach; j++) {
+                pushes.add(junk());
+            }
+            psbt.getPsbtInputs().get(i).setFinalScriptWitness(new TransactionWitness(null, pushes));
+        }
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(1, counts[0], "the honest input was never checked, so a crafted one silenced it");
+        Assertions.assertEquals(1, counts[1]);
+        //Each crafted input carries more pushes than a spend needs, so it is now refused before any of them is
+        //parsed and counts as a bounded block of present-and-unread rather than push by push. What matters is
+        //unchanged: it is still present, so the answer stays open, and it cost the honest input nothing.
+        Assertions.assertTrue(counts[2] > counts[1], "the crafted inputs still have to leave the answer open");
+        Assertions.assertTrue(counts[2] >= crafted * 1024, "and still have to count as present");
+    }
+
+    /**
+     * A push that is provably not a signature must not make "not replay protected" unreachable.
+     *
+     * An uncompressed public key is 65 bytes and decodes as a Schnorr signature, so a finalised legacy input carries
+     * one beside its real signature. Counting it would leave something present that could never be checked, which
+     * reads as "not checked" forever, and hands anyone supplying a transaction a one push way to arrange that.
+     */
+    @Test
+    public void a_public_key_beside_a_signature_does_not_make_the_answer_unknowable() {
+        PSBT psbt = signed(SigHash.ALL.byteValue());
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        TransactionSignature signature = psbtInput.getPartialSignature(ECKey.fromPublicOnly(outputKey));
+
+        //An uncompressed key, which is what a legacy input pushes beside its signature
+        byte[] uncompressed = new byte[65];
+        Arrays.fill(uncompressed, (byte)0x11);
+        uncompressed[0] = 0x04;
+        psbtInput.setFinalScriptWitness(new TransactionWitness(null, List.of(signature.encodeToBitcoin(), uncompressed)));
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(0, counts[0], "the signature does not opt in");
+        Assertions.assertEquals(1, counts[1], "the signature was checked");
+        Assertions.assertEquals(1, counts[2],
+                "the public key is not a signature, so nothing is left unchecked and the answer is a finding");
+    }
+
+    /**
+     * The risk count is read the other way round, from everything that looks like a signature, because naming a risk
+     * that is not there costs a warning and missing one costs the warning that mattered.
+     */
+    @Test
+    public void the_liftable_count_still_reads_every_push() {
+        PSBT psbt = signed((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue()));
+        byte[] legacyAnyoneCanPay = new byte[65];
+        Arrays.fill(legacyAnyoneCanPay, (byte)0x11);
+        legacyAnyoneCanPay[64] = (byte)(SigHash.ANYONECANPAY.value | SigHash.ALL.byteValue());
+        finaliseWith(psbt, legacyAnyoneCanPay);
+
+        Assertions.assertEquals(1, AppServices.liftableSignatureCount(psbt),
+                "a push that could be a liftable signature must still be reported");
+    }
+
+    /**
+     * An input that was skipped stays in the denominator, so the caller can still tell it was skipped.
+     *
+     * The filter on the denominator exists to stop a crafted push inflating it against a reading that did happen. On an
+     * input no reading happened for it did the reverse: an uncompressed public key is 65 bytes and decodes as a
+     * signature, so a refused input made only of them counted zero checked and zero present, and vanished from both
+     * counts. A transaction whose other input is honest and legacy then reads as every signature checked and none
+     * opting in, which is a settled "not replay protected" over an input that was never looked at and may carry the
+     * opt-in. One signature that opts in anywhere is enough, so that answer is not this wallet's to give.
+     */
+    @Test
+    public void an_input_the_budget_skipped_is_still_counted_as_present() {
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addInput(Sha256Hash.ZERO_HASH, 1, new Script(new byte[0]));
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            psbtInput.setSigHash(SigHash.ALL);
+        }
+
+        //Checked, and found to be the old kind, which on its own is a settled answer
+        Assertions.assertTrue(psbt.getPsbtInputs().get(0).sign(outputKey), "the honest input must be signed");
+
+        //Refused before a check runs, because it asks for more than one input may, and made of pushes the denominator
+        //filter excludes: 65 bytes beginning 0x04 is the uncompressed public key encoding
+        List<byte[]> pushes = new ArrayList<>();
+        for(int i = 0; i < MAX_INPUT_PUSHES + 1; i++) {
+            byte[] push = new byte[65];
+            Arrays.fill(push, (byte)0x11);
+            push[0] = 0x04;
+            pushes.add(push);
+        }
+        psbt.getPsbtInputs().get(1).setFinalScriptWitness(new TransactionWitness(null, pushes));
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(0, counts[0]);
+        Assertions.assertEquals(1, counts[1], "only the honest input could be checked");
+        Assertions.assertTrue(counts[2] > counts[1],
+                "the skipped input has to stay present, or nothing tells the caller it went unchecked");
+    }
+
+    /**
+     * A signature is not a control block because it happens to start like one.
+     *
+     * isTaprootControlBlock and isPubKey are shape tests: 65 bytes beginning 0xc0 or 0xc1 is the first, 65 beginning
+     * 0x04 the second, and about three in 256 Schnorr signatures begin with one of those. A finalised taproot key path
+     * input carries exactly one push, its signature, so filtering by shape alone discards it: the Anyone Can Pay
+     * warning goes missing, and where the signature also fails to verify the input leaves the denominator entirely and
+     * a transaction whose other input checks out reads as settled.
+     *
+     * Those pushes sit last, after the signatures, so the position is what tells them apart.
+     */
+    @Test
+    public void a_lone_signature_shaped_like_a_control_block_is_still_a_signature() {
+        for(byte first : new byte[] {(byte)0xc0, (byte)0xc1, 0x04}) {
+            byte[] signature = new byte[65];
+            Arrays.fill(signature, (byte)0x33);
+            signature[0] = first;
+            signature[64] = (byte)(SigHash.ALL.byteValue() | SigHash.ANYONECANPAY.value);
+
+            PSBT psbt = signed(SigHash.ALL.byteValue());
+            PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+            psbtInput.getPartialSignatures().clear();
+            //One push, which is what a taproot key path spend finalises to
+            psbtInput.setFinalScriptWitness(new TransactionWitness(null, List.of(signature)));
+
+            Assertions.assertEquals(1, AppServices.liftableSignatureCount(psbt),
+                    String.format("a lone signature beginning 0x%02x lost its Anyone Can Pay warning", first));
+            Assertions.assertTrue(AppServices.signatureOptInCounts(psbt, trusted())[2] > 0,
+                    String.format("a lone signature beginning 0x%02x left the denominator", first));
+        }
+    }
+
+    /** And the pushes that really are those things, in the position they really sit, are still left out. */
+    @Test
+    public void a_public_key_or_control_block_in_its_own_position_is_still_excluded() {
+        byte[] pubKey = new byte[65];
+        Arrays.fill(pubKey, (byte)0x11);
+        pubKey[0] = 0x04;
+        pubKey[64] = (byte)(SigHash.ALL.byteValue() | SigHash.ANYONECANPAY.value);
+
+        PSBT withPubKey = signed(SigHash.ALL.byteValue());
+        finaliseWith(withPubKey, pubKey);
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(withPubKey),
+                "the real signature signs All, and the trailing push is a public key rather than a second signature");
+    }
+
+    /**
+     * The budget has to reach the end of a consolidation a quorum signed, which is the shape this whole reading exists
+     * for. It was charging keys times signatures against a budget scaled for the expensive part, and the expensive part
+     * is the message: one is built per distinct hash type and remembered, so an input costs one however many keys
+     * vouch for it. A 2 of 3 was charged six times what it spends, and the label read "not checked" for the wallet
+     * this feature is aimed at.
+     */
+    @Test
+    public void a_quorum_signed_consolidation_is_checked_to_the_end() {
+        int inputs = 200;
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key());
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i < inputs; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        //Every spent output first: the opted-in message commits to all of them, so none can be signed until all are set
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            psbtInput.setSigHash(SigHash.fromByte((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue())));
+        }
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            Assertions.assertTrue(psbtInput.sign(outputKey), "every input must be signed");
+        }
+
+        //Three keys vouched for, as a quorum's worth would be, against one signature on each input
+        List<ECKey> quorum = new ArrayList<>(trusted());
+        quorum.add(ECKey.fromPublicOnly(ECKey.fromPrivate(Utils.hexToBytes("22".repeat(32))).getPubKey()));
+        quorum.add(ECKey.fromPublicOnly(ECKey.fromPrivate(Utils.hexToBytes("33".repeat(32))).getPubKey()));
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, quorum);
+        Assertions.assertEquals(inputs, counts[1], "the budget stopped short of the end of an ordinary consolidation");
+        Assertions.assertEquals(inputs, counts[0], "every signature opts in, so every one of them has to be counted");
+    }
+
+    /**
+     * An 11 of 15 consolidation, which is the largest ordinary quorum and the shape the old accounting put out of
+     * reach: 165 checks charged an input that actually spends 11, so the budget ran out a fifth of the way in and the
+     * label read "not checked" for the wallet most in need of it.
+     */
+    @Test
+    public void a_large_quorum_consolidation_is_checked_to_the_end() {
+        int inputs = 100;
+        int keyCount = 15;
+        int threshold = 11;
+
+        List<ECKey> keys = new ArrayList<>();
+        for(int i = 0; i < keyCount; i++) {
+            keys.add(ECKey.fromPrivate(Utils.hexToBytes(String.format("%02x", i + 1).repeat(32))));
+        }
+        Script witnessScript = ScriptType.MULTISIG.getOutputScript(threshold, keys);
+        Script spk = ScriptType.P2WSH.getOutputScript(witnessScript);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i < inputs; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            psbtInput.setWitnessScript(witnessScript);
+            psbtInput.setSigHash(SigHash.fromByte((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue())));
+        }
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            for(int i = 0; i < threshold; i++) {
+                Assertions.assertTrue(psbtInput.sign(keys.get(i)), "every input must be signed by the quorum");
+            }
+        }
+
+        List<ECKey> trusted = new ArrayList<>();
+        for(ECKey key : keys) {
+            trusted.add(ECKey.fromPublicOnly(key));
+        }
+
+        long start = System.nanoTime();
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted);
+        long ms = (System.nanoTime() - start) / 1_000_000;
+
+        Assertions.assertEquals(inputs * threshold, counts[1],
+                "the budget stopped short of the end of an 11 of 15 consolidation");
+        Assertions.assertEquals(inputs * threshold, counts[0], "every signature opts in");
+        Assertions.assertTrue(ms < 2000, "this runs while a screen is drawing, and took " + ms + "ms");
+    }
+
+
+    /**
+     * The liftable warning walks every push in the transaction and nothing else caps them: four million measured two
+     * seconds on the drawing thread, and gave a count no sentence should carry. Bounded now. Stopping early can only
+     * leave a warning unsaid, and a transaction that reaches the cap already reads as not checked from the counts.
+     */
+    @Test
+    public void the_liftable_warning_does_not_walk_a_transaction_without_end() {
+        int inputs = 100;
+        int pushesEach = 1000;
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i < inputs; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            List<byte[]> pushes = new ArrayList<>();
+            for(int j = 0; j < pushesEach; j++) {
+                byte[] push = new byte[65];
+                Arrays.fill(push, (byte)0x33);
+                push[64] = (byte)(SigHash.ALL.byteValue() | SigHash.ANYONECANPAY.value);
+                pushes.add(push);
+            }
+            psbtInput.setFinalScriptWitness(new TransactionWitness(null, pushes));
+        }
+
+        int liftable = AppServices.liftableSignatureCount(psbt);
+        Assertions.assertTrue(liftable < inputs * pushesEach,
+                "every push in the transaction was walked, and nothing bounds how many there are");
+        Assertions.assertTrue(liftable > 0, "and what it did look at is still reported");
+    }
+
+    /** An ordinary transaction is nowhere near that, so its count is exact. */
+    @Test
+    public void an_ordinary_transaction_still_gets_an_exact_liftable_count() {
+        byte legacyAnyoneCanPay = (byte)(SigHash.ALL.byteValue() | SigHash.ANYONECANPAY.value);
+        PSBT psbt = signed(legacyAnyoneCanPay);
+
+        Assertions.assertEquals(1, AppServices.liftableSignatureCount(psbt));
+    }
+
+    /**
+     * An input carrying more pushes than any spend needs is refused before any of them is parsed.
+     *
+     * Every other ceiling here counts signatures, and a witness may carry any number of pushes that are not signature
+     * shaped: nothing counting signatures sees them, and each is still parsed and offered to the signature decoder,
+     * three times over. A hundred inputs of a hundred thousand of them measured two and a half minutes on the thread
+     * that draws. It still has to count as present, or an input nobody looked at leaves the answer settled.
+     */
+    @Test
+    public void an_input_of_more_pushes_than_a_spend_needs_is_not_parsed() {
+        int inputs = 2;
+        int tinyPushes = 2000;
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i < inputs; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+            psbtInput.setSigHash(SigHash.ALL);
+
+            List<byte[]> pushes = new ArrayList<>();
+            byte[] signature = new byte[65];
+            Arrays.fill(signature, (byte)0x33);
+            signature[64] = SigHash.ALL.byteValue();
+            pushes.add(signature);
+            for(int j = 0; j < tinyPushes; j++) {
+                pushes.add(new byte[] {0x01});
+            }
+            psbtInput.setFinalScriptWitness(new TransactionWitness(null, pushes));
+        }
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(0, counts[0], "nothing was checked, so nothing may be reported as opting in");
+        Assertions.assertEquals(0, counts[1]);
+        Assertions.assertTrue(counts[2] >= inputs * 1024,
+                "an input this refused to read still has to count as present, or the answer reads as settled");
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(psbt),
+                "and the liftable walk refuses it for the same reason");
+    }
+
+    /** An ordinary witness is nowhere near that, so it is read as before. */
+    @Test
+    public void an_ordinary_witness_is_still_read() {
+        PSBT psbt = signed(SigHash.ALL.byteValue());
+        finaliseWith(psbt);
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, trusted());
+        Assertions.assertEquals(1, counts[1], "a real spend carries a handful of pushes and is checked");
+        Assertions.assertEquals(1, counts[2]);
+    }
+
+    /**
+     * Inputs belonging to someone else must cost the transaction nothing, asked through the wallet.
+     *
+     * A coinjoin or a payjoin proposal is mostly inputs this wallet holds no key for, and it vouches for none of them.
+     * An input that names its keys was charged for its signatures whether or not any key was vouched for, so enough
+     * of them ahead of the wallet's own spent the budget without a check being made and the honest input read as
+     * unchecked. Every other test here uses the key list overload, where every input has trusted keys.
+     */
+    @Test
+    public void foreign_inputs_do_not_silence_the_wallet_s_own() throws Exception {
+        int foreign = 8;
+        int signaturesEach = 512;
+
+        com.sparrowwallet.drongo.wallet.Wallet wallet = new com.sparrowwallet.drongo.wallet.Wallet();
+        wallet.setPolicyType(PolicyType.SINGLE_HD);
+        wallet.setScriptType(ScriptType.P2WPKH);
+        wallet.getKeystores().add(com.sparrowwallet.drongo.wallet.Keystore.fromSeed(new com.sparrowwallet.drongo.wallet.DeterministicSeed(
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor", "", 0,
+                com.sparrowwallet.drongo.wallet.DeterministicSeed.Type.BIP39), PolicyType.SINGLE_HD, ScriptType.P2WPKH.getDefaultDerivation()));
+        wallet.setDefaultPolicy(com.sparrowwallet.drongo.policy.Policy.getPolicy(PolicyType.SINGLE_HD, ScriptType.P2WPKH, wallet.getKeystores(), null));
+        wallet.getNode(com.sparrowwallet.drongo.KeyPurpose.RECEIVE);
+
+        com.sparrowwallet.drongo.wallet.WalletNode node = wallet.getNode(com.sparrowwallet.drongo.KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script ours = wallet.getOutputScript(node);
+        Script theirs = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD,
+                ECKey.fromPrivate(Utils.hexToBytes("99".repeat(32))));
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        for(int i = 0; i <= foreign; i++) {
+            transaction.addInput(Sha256Hash.ZERO_HASH, i, new Script(new byte[0]));
+        }
+        transaction.addOutput(VALUE - 10_000, ours);
+
+        List<ECKey> strangers = new ArrayList<>();
+        for(int i = 0; i < signaturesEach; i++) {
+            //A fixed body with a varying tail, so every one is a distinct key well inside the valid range
+            strangers.add(ECKey.fromPublicOnly(ECKey.fromPrivate(
+                    Utils.hexToBytes("11".repeat(30) + String.format("%04x", i + 1))).getPubKey()));
+        }
+
+        PSBT psbt = new PSBT(transaction);
+        for(int i = 0; i < foreign; i++) {
+            PSBTInput psbtInput = psbt.getPsbtInputs().get(i);
+            psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, theirs.getProgram()));
+            psbtInput.setSigHash(SigHash.ALL);
+            byte[] push = new byte[65];
+            Arrays.fill(push, (byte)0x33);
+            push[64] = SigHash.ALL.byteValue();
+            for(ECKey stranger : strangers) {
+                psbtInput.getPartialSignatures().put(stranger,
+                        TransactionSignature.decodeFromBitcoin(TransactionSignature.Type.SCHNORR, push, false));
+            }
+        }
+
+        //The wallet's own input, last, so anything the others consume is consumed before it is reached
+        PSBTInput honest = psbt.getPsbtInputs().get(foreign);
+        honest.setWitnessUtxo(new TransactionOutput(null, VALUE, ours.getProgram()));
+        honest.setSigHash(SigHash.fromByte((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue())));
+        honest.getDerivedPublicKeys().put(node.getPubKey(),
+                wallet.getKeystores().get(0).getKeyDerivation().extend(node.getDerivation()));
+        Assertions.assertTrue(honest.sign(wallet.getKeystores().get(0).getKey(node)), "the honest input must be signed");
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, wallet);
+        Assertions.assertEquals(1, counts[1], "the wallet's own input was never checked, so a stranger's silenced it");
+        Assertions.assertEquals(1, counts[0], "and its signature opts in");
+    }
+
+    /**
+     * A scriptSig that does not parse must not throw from the counting.
+     *
+     * The push count is read before the per input guard, because refusing an input has to be cheaper than reading it.
+     * That put a script parse outside the guard for the first time, so what it does with a script it cannot read
+     * decides whether a label survives a truncated one.
+     */
+    @Test
+    public void a_scriptsig_that_does_not_parse_is_counted_rather_than_thrown() {
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+        psbtInput.setSigHash(SigHash.ALL);
+        //OP_PUSHDATA1 with no length byte after it, then a push claiming more bytes than follow
+        psbtInput.setFinalScriptSig(new Script(new byte[] {0x4c}));
+
+        int[] counts = Assertions.assertDoesNotThrow(() -> AppServices.signatureOptInCounts(psbt, trusted()));
+        Assertions.assertEquals(0, counts[0], "nothing readable opts in");
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(psbt));
+
+        psbtInput.setFinalScriptSig(new Script(new byte[] {0x4b, 0x01, 0x02}));
+        Assertions.assertDoesNotThrow(() -> AppServices.signatureOptInCounts(psbt, trusted()),
+                "a push claiming more bytes than follow it is still only an unreadable script");
+    }
+
+}

--- a/src/test/java/com/sparrowwallet/sparrow/SignatureOptInCountTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/SignatureOptInCountTest.java
@@ -1,0 +1,32 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.protocol.TransactionSignature;
+import com.sparrowwallet.drongo.protocol.TransactionWitness;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * What the replay protection label is counted from, at the surface that feeds it.
+ *
+ * The two numbers are claimed in opposite directions and so are counted differently. The first says a protection is
+ * there, and only a signature that verifies can say that. The second is the denominator, and leaving an unverifiable
+ * signature out of it would turn "one of two signatures opted in" into "every signature opted in".
+ */
+public class SignatureOptInCountTest {
+    private static final String PRIVATE_KEY = "11".repeat(32);
+    private static final long VALUE = 100_000_000L;}

--- a/src/test/java/com/sparrowwallet/sparrow/SparrowSendHarness.java
+++ b/src/test/java/com/sparrowwallet/sparrow/SparrowSendHarness.java
@@ -37,15 +37,26 @@ public class SparrowSendHarness {
      * P2WPKH input takes the implied P2PKH script instead. Every other end to end test here spends
      * P2WPKH, so this is the one that exercises the other branch of that choice.
      */
+    private static final String MNEMONIC3 = "quantum lens tag pencil kingdom obey noise pigeon oyster shoulder ordinary tilt";
+
     private static Wallet multisigWallet() throws Exception {
+        return multisigWallet(false);
+    }
+
+    /** spare = a 2 of 3, so every signer signing leaves one signature more than the threshold needs. */
+    private static Wallet multisigWallet(boolean spare) throws Exception {
+        return multisigWallet(spare, ScriptType.P2WSH);
+    }
+
+    private static Wallet multisigWallet(boolean spare, ScriptType scriptType) throws Exception {
         Wallet wallet = new Wallet();
         wallet.setPolicyType(PolicyType.MULTI_HD);
-        wallet.setScriptType(ScriptType.P2WSH);
-        for(String mnemonic : new String[] {MNEMONIC, MNEMONIC2}) {
+        wallet.setScriptType(scriptType);
+        for(String mnemonic : spare ? new String[] {MNEMONIC, MNEMONIC2, MNEMONIC3} : new String[] {MNEMONIC, MNEMONIC2}) {
             DeterministicSeed seed = new DeterministicSeed(mnemonic, "", 0, DeterministicSeed.Type.BIP39);
             wallet.getKeystores().add(Keystore.fromSeed(seed, PolicyType.MULTI_HD, wallet.getScriptType().getDefaultDerivation()));
         }
-        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, ScriptType.P2WSH, wallet.getKeystores(), 2));
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, scriptType, wallet.getKeystores(), 2));
         wallet.getNode(KeyPurpose.RECEIVE);
         return wallet;
     }
@@ -88,15 +99,20 @@ public class SparrowSendHarness {
 
     public static void main(String[] args) throws Exception {
         boolean mixed = args[0].startsWith("mixed-");
+        //forged- adds a signature made by a key of the stranger's over the opted-in message, which is what anyone
+        //handing you a PSBT can do. Finalising drops it, so the transaction that broadcasts carries no opt-in.
+        boolean forged = args[0].startsWith("forged-");
         //watchonly- decides with a marked watch only wallet and signs with a separate one holding the key,
         //which is the wallet-plus-external-signer split this mode exists to prove
         boolean watchOnly = args[0].startsWith("watchonly-") || args[0].startsWith("watchonlyunmarked-");
         boolean watchOnlyMarked = args[0].startsWith("watchonly-");
-        String mode0 = mixed ? args[0].substring("mixed-".length())
+        String mode0 = forged ? args[0].substring("forged-".length())
+                : mixed ? args[0].substring("mixed-".length())
                 : (watchOnlyMarked ? args[0].substring("watchonly-".length())
                 : (watchOnly ? args[0].substring("watchonlyunmarked-".length()) : args[0]));
         boolean multisig = mode0.endsWith("-multi");
-        String mode = multisig ? mode0.substring(0, mode0.length() - "-multi".length()) : mode0;
+        //Stripped only where it is actually there: spare sets multisig without naming the suffix
+        String mode = mode0.endsWith("-multi") ? mode0.substring(0, mode0.length() - "-multi".length()) : mode0;
         Wallet wallet = multisig ? multisigWallet() : (watchOnly ? watchOnlyWallet(watchOnlyMarked) : wallet());
 
         if("scriptpubkey".equals(mode)) {
@@ -130,8 +146,16 @@ public class SparrowSendHarness {
         if(multisig) {
             //A P2WSH input carries the witnessScript; it is also the script code the unified message
             //commits to, where a P2WPKH input uses the implied P2PKH script instead.
-            psbtInput.setWitnessScript(ScriptType.MULTISIG.getOutputScript(
-                    wallet.getDefaultPolicy().getNumSignaturesRequired(), receiveNode.getPubKeys()));
+            Script multisigScript = ScriptType.MULTISIG.getOutputScript(
+                    wallet.getDefaultPolicy().getNumSignaturesRequired(), receiveNode.getPubKeys());
+            if(wallet.getScriptType() == ScriptType.P2SH) {
+                psbtInput.setRedeemScript(multisigScript);
+            } else if(wallet.getScriptType() == ScriptType.P2SH_P2WSH) {
+                psbtInput.setRedeemScript(ScriptType.P2WSH.getOutputScript(multisigScript));
+                psbtInput.setWitnessScript(multisigScript);
+            } else {
+                psbtInput.setWitnessScript(multisigScript);
+            }
         }
         //What PSBT(WalletTransaction) sets for a non-taproot input, which the opt-in is applied on top of
         psbtInput.setSigHash(SigHash.ALL);
@@ -168,14 +192,38 @@ public class SparrowSendHarness {
         } else {
             wallet.sign(psbt);
         }
+
+
+        if(forged) {
+            //Signed the way this wallet signs, then a signature of the stranger's added over the opted-in message.
+            //The label used to read the hash type off that push and report the transaction as protected.
+            com.sparrowwallet.drongo.crypto.ECKey stranger = com.sparrowwallet.drongo.crypto.ECKey.fromPrivate(Utils.hexToBytes("77".repeat(32)));
+            SigHash declared = psbtInput.getSigHash();
+            psbtInput.setSigHash(SigHash.UNIFIED_ALL);
+            psbtInput.sign(stranger);
+            psbtInput.setSigHash(declared);
+
+            //What the transaction view shows for the combined PSBT, which is the moment a user decides to broadcast
+            int[] combined = AppServices.signatureOptInCounts(psbt, wallet);
+            System.out.println("FORGED_PRESENT=" + psbtInput.getPartialSignatures().size());
+            System.out.println("COMBINED_OPTED_IN=" + combined[0]);
+            System.out.println("COMBINED_PRESENT=" + combined[2]);
+        }
+
         if(!watchOnly) {
             wallet.finalise(psbt);
         }
         Transaction finalTx = psbt.extractTransaction();
 
         TransactionWitness witness = finalTx.getInputs().getFirst().getWitness();
+        java.util.List<TransactionSignature> finalSignatures = witness != null && !witness.getPushes().isEmpty()
+                ? witness.getSignatures() : finalTx.getInputs().getFirst().getScriptSig().getSignatures();
+        if(finalSignatures.isEmpty()) {
+            throw new IllegalStateException("No signatures were produced");
+        }
         if(witness == null || witness.getPushes().isEmpty()) {
-            throw new IllegalStateException("No witness was produced");
+            //A legacy P2SH spend carries its signatures in the scriptSig
+            witness = new TransactionWitness(null, java.util.List.of(finalSignatures.getFirst().encodeToBitcoin()));
         }
         //A P2WSH multisig witness starts with the empty element CHECKMULTISIG consumes, and ends with
         //the witnessScript, so take the first push that actually looks like a signature.
@@ -185,6 +233,14 @@ public class SparrowSendHarness {
                 .orElse(witness.getPushes().getFirst());
 
         System.out.println("SIGHASH_BYTE=" + String.format("%02x", signature[signature.length - 1]));
+        //Every hash type the finalised witness kept, so a caller can see whether the opted-in one survived the choice
+        System.out.println("KEPT_SIGHASH_BYTES=" + finalSignatures.stream()
+                .map(kept -> String.format("%02x", kept.sighashFlags)).collect(java.util.stream.Collectors.joining(",")));
+        //What the transaction view counts the replay protection label from, on the PSBT this run actually signed. The
+        //first number is claimed as a protection so it counts only signatures that verify; the second is what is there.
+        int[] counts = AppServices.signatureOptInCounts(psbt, wallet);
+        System.out.println("VERIFIED_OPTED_IN=" + counts[0]);
+        System.out.println("SIGNATURES_PRESENT=" + counts[2]);
         System.out.println("RAWTX=" + Utils.bytesToHex(finalTx.bitcoinSerialize()));
     }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/TapScriptSignedTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/TapScriptSignedTest.java
@@ -1,0 +1,235 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.protocol.VarInt;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+/**
+ * A transaction signed only by a taproot script path is a signed transaction.
+ *
+ * The whole point of this reading is that a declaration is not a check. An input carrying only script path signatures
+ * used to arrive with nothing a wallet could see: they were dropped at parse, so it had no partial signatures, no key
+ * path signature and nothing finalised, which is what an unsigned input looks like. The label then said what the
+ * transaction would be, taken from a hash type the file wrote for itself, over a transaction that was already signed
+ * and whose signatures nobody had looked at.
+ *
+ * Built by writing the entry into a real PSBT's bytes and handing those to the real parser, so what is checked is the
+ * path a PSBT from another wallet actually takes.
+ */
+public class TapScriptSignedTest {
+    private static final String PRIVATE_KEY = "11".repeat(32);
+    private static final long VALUE = 100_000_000L;
+
+    public static PSBT declaredUnifiedPsbt() {
+        ECKey key = ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY));
+        //Taproot, because a script path signature belongs to a taproot input and is ignored anywhere else
+        Script spk = ScriptType.P2TR.getOutputScript(PolicyType.SINGLE_HD, key);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+        psbtInput.setSigHash(SigHash.fromByte((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue())));
+
+        return psbt;
+    }
+
+    /**
+     * The entry, written into the first input's map. The global map ends at the first zero length key after the magic,
+     * and the first input's map begins there, so an entry inserted at that point belongs to input zero.
+     */
+    public static byte[] withTapScriptSignature(byte[] serialized, byte sigHashType) {
+        byte[] signature = new byte[65];
+        Arrays.fill(signature, (byte)0x33);
+        signature[64] = sigHashType;
+
+        return withTapScriptSignature(serialized, signature);
+    }
+
+    public static byte[] withTapScriptSignature(byte[] serialized, byte[] signature) {
+        int offset = 5;
+        while(true) {
+            VarInt keyLength = new VarInt(serialized, offset);
+            offset += keyLength.getOriginalSizeInBytes();
+            if(keyLength.value == 0) {
+                break;
+            }
+            offset += (int)keyLength.value;
+            VarInt dataLength = new VarInt(serialized, offset);
+            offset += dataLength.getOriginalSizeInBytes() + (int)dataLength.value;
+        }
+
+        byte[] keyData = Utils.hexToBytes("aa".repeat(32) + "bb".repeat(32));
+        byte[] key = new byte[1 + keyData.length];
+        key[0] = PSBTInput.PSBT_IN_TAP_SCRIPT_SIG;
+        System.arraycopy(keyData, 0, key, 1, keyData.length);
+
+        ByteArrayOutputStream spliced = new ByteArrayOutputStream();
+        spliced.writeBytes(Arrays.copyOfRange(serialized, 0, offset));
+        spliced.writeBytes(new VarInt(key.length).encode());
+        spliced.writeBytes(key);
+        spliced.writeBytes(new VarInt(signature.length).encode());
+        spliced.writeBytes(signature);
+        spliced.writeBytes(Arrays.copyOfRange(serialized, offset, serialized.length));
+
+        return spliced.toByteArray();
+    }
+
+    public static PSBT signedByScriptPath(byte sigHashType) throws Exception {
+        PSBT psbt = new PSBT(withTapScriptSignature(declaredUnifiedPsbt().serialize(), sigHashType), false);
+        Assertions.assertEquals(1, psbt.getPsbtInputs().get(0).getTapScriptSignatures().size(),
+                "the fixture has to carry the signature, or this test proves nothing");
+        return psbt;
+    }
+
+    /**
+     * Present and unverifiable is not the same as absent. The leaf script these are made against is not parsed, so they
+     * can never reach the verified count, and counting them is what makes the pair say so.
+     */
+    @Test
+    public void a_script_path_signature_counts_as_something_present_and_unchecked() throws Exception {
+        int[] counts = AppServices.signatureOptInCounts(signedByScriptPath(SigHash.ALL.byteValue()),
+                java.util.List.of(ECKey.fromPublicOnly(ScriptType.P2TR.getOutputKey(PolicyType.SINGLE_HD,
+                        ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY))))));
+
+        Assertions.assertEquals(0, counts[0], "nothing was verified, so nothing may be reported as opting in");
+        Assertions.assertEquals(0, counts[1]);
+        Assertions.assertTrue(counts[2] > counts[1],
+                "a signature that is present and cannot be checked has to leave the answer open");
+    }
+
+    /**
+     * And the same where the last byte of the signature says it opts in. Reading that byte off a signature nothing
+     * verified is the forgery this whole reading exists to refuse, so it must not become an opt-in here either.
+     */
+    @Test
+    public void one_whose_last_byte_claims_the_opt_in_is_still_not_counted() throws Exception {
+        int[] counts = AppServices.signatureOptInCounts(
+                signedByScriptPath((byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue())),
+                java.util.List.of(ECKey.fromPublicOnly(ScriptType.P2TR.getOutputKey(PolicyType.SINGLE_HD,
+                        ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY))))));
+
+        Assertions.assertEquals(0, counts[0], "a byte in an unverified signature is not evidence of anything");
+        Assertions.assertTrue(counts[2] > counts[1]);
+    }
+
+    /**
+     * An input that omits its spent output is not recognisable as taproot, and its script path signature still counts.
+     *
+     * Narrowing the count to taproot inputs looked tidy and was wrong: isTaproot turns on the spent output being
+     * present, and whoever writes the PSBT chooses whether to include it. Left out, the signature stops reaching
+     * either count, and a transaction whose other input checks out reads as fully checked with nothing opting in,
+     * which is a settled claim over an entry nobody looked at.
+     */
+    @Test
+    public void a_script_path_signature_counts_even_where_the_spent_output_is_missing() throws Exception {
+        PSBT psbt = signedByScriptPath(SigHash.ALL.byteValue());
+        psbt.getPsbtInputs().get(0).setWitnessUtxo(null);
+        Assertions.assertFalse(psbt.getPsbtInputs().get(0).isTaproot(),
+                "the fixture has to be unrecognisable as taproot, or this test proves nothing");
+
+        int[] counts = AppServices.signatureOptInCounts(psbt, java.util.List.of());
+        Assertions.assertEquals(0, counts[0]);
+        Assertions.assertEquals(0, counts[1]);
+        Assertions.assertTrue(counts[2] > 0, "a signature this cannot check has to leave the answer open");
+    }
+
+    /**
+     * And the same beside an input that does check out. This is the shape that turns a dropped signature into a
+     * settled wrong answer rather than a merely incomplete one: without it the transaction reads as every signature
+     * checked and none opting in.
+     */
+    @Test
+    public void an_unreadable_signature_beside_a_readable_one_still_holds_the_answer_open() throws Exception {
+        ECKey key = ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY));
+        ECKey outputKey = ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, key);
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key);
+        Script taprootSpk = ScriptType.P2TR.getOutputScript(PolicyType.SINGLE_HD, key);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addInput(Sha256Hash.ZERO_HASH, 1, new Script(new byte[0]));
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        //Input zero takes the script path signature, spliced in below, and is never checkable
+        PSBTInput unreadable = psbt.getPsbtInputs().get(0);
+        unreadable.setWitnessUtxo(new TransactionOutput(null, VALUE, taprootSpk.getProgram()));
+        unreadable.setSigHash(SigHash.ALL);
+
+        //Input one is signed for real and the old way, so on its own the answer would be settled
+        PSBTInput honest = psbt.getPsbtInputs().get(1);
+        honest.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+        honest.setSigHash(SigHash.ALL);
+        Assertions.assertTrue(honest.sign(outputKey), "the honest input must be signed");
+
+        //The splice lands in the first input's map, which is input zero
+        PSBT spliced = new PSBT(withTapScriptSignature(psbt.serialize(), SigHash.ALL.byteValue()), false);
+        Assertions.assertEquals(1, spliced.getPsbtInputs().get(0).getTapScriptSignatures().size(),
+                "the fixture has to carry the signature, or this test proves nothing");
+
+        int[] counts = AppServices.signatureOptInCounts(spliced, java.util.List.of(ECKey.fromPublicOnly(outputKey)));
+        Assertions.assertEquals(0, counts[0], "nothing verified opts in");
+        Assertions.assertEquals(1, counts[1], "one input checked out");
+        Assertions.assertTrue(counts[2] > counts[1],
+                "the other carries something unreadable, so this is not entitled to call the answer settled");
+    }
+
+    /**
+     * A script path signature that signs Anyone Can Pay commits to its own input and the outputs and nothing else, so
+     * it can be lifted into another transaction and spent on the SHA256d chain. liftableCandidates reads the pushes an
+     * input carries and these travel in a field of their own, so the one warning that method exists to give went
+     * missing for every taproot script path spend.
+     */
+    @Test
+    public void a_script_path_signature_that_stands_alone_is_named_as_liftable() throws Exception {
+        byte legacyAnyoneCanPay = (byte)(SigHash.ALL.byteValue() | SigHash.ANYONECANPAY.value);
+        Assertions.assertEquals(1, AppServices.liftableSignatureCount(signedByScriptPath(legacyAnyoneCanPay)),
+                "this one can be lifted out and spent, which is the whole of the warning");
+
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(signedByScriptPath(SigHash.ALL.byteValue())),
+                "one that commits to every input cannot be lifted anywhere");
+
+        byte unifiedAnyoneCanPay = (byte)(SigHash.UNIFIED_FLAG | SigHash.ALL.byteValue() | SigHash.ANYONECANPAY.value);
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(signedByScriptPath(unifiedAnyoneCanPay)),
+                "one that opts in is not valid under the pre-fork rules to begin with, so there is nowhere to lift it");
+    }
+
+    /**
+     * A 64 byte signature carries no hash type byte at all. That is the default type, which commits to every input, so
+     * there is nothing to lift and nothing to read off the end of it.
+     */
+    @Test
+    public void a_signature_with_no_hash_type_byte_is_not_read_as_one() throws Exception {
+        PSBT psbt = declaredUnifiedPsbt();
+        byte[] serialized = psbt.serialize();
+
+        byte[] shortSignature = new byte[64];
+        java.util.Arrays.fill(shortSignature, (byte)0x33);
+        PSBT parsed = new PSBT(withTapScriptSignature(serialized, shortSignature), false);
+
+        Assertions.assertEquals(1, parsed.getPsbtInputs().get(0).getTapScriptSignatures().size());
+        Assertions.assertEquals(0, AppServices.liftableSignatureCount(parsed));
+        Assertions.assertTrue(AppServices.signatureOptInCounts(parsed, java.util.List.of())[2] > 0,
+                "it is still present and still cannot be checked");
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/TrustedKeysTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/TrustedKeysTest.java
@@ -1,0 +1,226 @@
+package com.sparrowwallet.sparrow;
+
+import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.KeyDerivation;
+import com.sparrowwallet.drongo.crypto.ChildNumber;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.policy.Policy;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import com.sparrowwallet.drongo.wallet.DeterministicSeed;
+import com.sparrowwallet.drongo.wallet.FinalizingPSBTWallet;
+import com.sparrowwallet.drongo.wallet.Keystore;
+import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.drongo.wallet.WalletNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Which keys the wallet will stand behind for an input, which is the whole of what the replay protection label rests on.
+ *
+ * A signature counts as an opt-in only where a key from here made it. Everything an input carries about its keys was
+ * written by whoever wrote the input, so trusting any of that would answer "did someone sign something", which anyone
+ * handing over a PSBT can arrange with a key of their own.
+ */
+public class TrustedKeysTest {
+    private Wallet wallet;
+    private WalletNode receiveNode;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Network.set(Network.MAINNET);
+        wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.SINGLE_HD);
+        wallet.setScriptType(ScriptType.P2WPKH);
+        DeterministicSeed seed = new DeterministicSeed(
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor", "", 0, DeterministicSeed.Type.BIP39);
+        wallet.getKeystores().add(Keystore.fromSeed(seed, PolicyType.SINGLE_HD, ScriptType.P2WPKH.getDefaultDerivation()));
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.SINGLE_HD, ScriptType.P2WPKH, wallet.getKeystores(), null));
+        wallet.getNode(KeyPurpose.RECEIVE);
+        receiveNode = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Network.set(null);
+    }
+
+    private PSBT lastPsbt;
+
+    /** A PSBT spending the given output, which is what the wallet is asked to vouch for. */
+    private PSBTInput inputSpending(Script utxoScript) {
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90_000L, wallet.getOutputScript(receiveNode));
+
+        PSBT psbt = new PSBT(transaction);
+        lastPsbt = psbt;
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100_000L, utxoScript.getProgram()));
+        psbtInput.setSigHash(SigHash.ALL);
+
+        return psbtInput;
+    }
+
+    @Test
+    public void the_wallet_vouches_for_its_own_node() {
+        Set<ECKey> keys = AppServices.trustedKeys(inputSpending(wallet.getOutputScript(receiveNode)), wallet, receiveNode);
+
+        Assertions.assertEquals(1, keys.size());
+        Assertions.assertTrue(keys.contains(ECKey.fromPublicOnly(receiveNode.getPubKey())),
+                "the key the wallet derives for this node is what it stands behind");
+    }
+
+    /**
+     * The spent output has to be the one this wallet derives. Everything the message is built from comes out of the
+     * PSBT, the amount included, so an input whose output the wallet did not derive is one where a stranger chose the
+     * message, and a signature over a message a stranger chose says nothing about the transaction being sent.
+     */
+    @Test
+    public void and_for_nothing_where_the_spent_output_is_not_the_one_it_derives() {
+        WalletNode otherNode = wallet.getNode(KeyPurpose.CHANGE).getChildren().iterator().next();
+        Script otherScript = wallet.getOutputScript(otherNode);
+
+        Assertions.assertTrue(AppServices.trustedKeys(inputSpending(otherScript), wallet, receiveNode).isEmpty(),
+                "the node and the spent output disagree, so there is nothing to vouch for");
+    }
+
+    @Test
+    public void nor_where_there_is_no_wallet_or_no_node() {
+        PSBTInput psbtInput = inputSpending(wallet.getOutputScript(receiveNode));
+
+        Assertions.assertTrue(AppServices.trustedKeys(psbtInput, null, receiveNode).isEmpty());
+        Assertions.assertTrue(AppServices.trustedKeys(psbtInput, wallet, null).isEmpty());
+    }
+
+    /**
+     * Taproot, where the key that signs is not the key the wallet derives.
+     *
+     * A key path signature verifies against the tweaked output key, so vouching for the untweaked one would verify
+     * nothing and report every taproot spend as unprotected. The output key is taken from the script this wallet
+     * derived, which is the same script the check above just matched.
+     */
+    @Test
+    public void a_taproot_wallet_vouches_for_the_output_key() throws Exception {
+        Wallet taproot = new Wallet();
+        taproot.setPolicyType(PolicyType.SINGLE_HD);
+        taproot.setScriptType(ScriptType.P2TR);
+        DeterministicSeed seed = new DeterministicSeed(
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor", "", 0, DeterministicSeed.Type.BIP39);
+        taproot.getKeystores().add(Keystore.fromSeed(seed, PolicyType.SINGLE_HD, ScriptType.P2TR.getDefaultDerivation()));
+        taproot.setDefaultPolicy(Policy.getPolicy(PolicyType.SINGLE_HD, ScriptType.P2TR, taproot.getKeystores(), null));
+        taproot.getNode(KeyPurpose.RECEIVE);
+        WalletNode node = taproot.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script script = taproot.getOutputScript(node);
+
+        Transaction transaction = new Transaction();
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90_000L, script);
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100_000L, script.getProgram()));
+
+        Set<ECKey> keys = AppServices.trustedKeys(psbtInput, taproot, node);
+        Assertions.assertEquals(1, keys.size());
+        Assertions.assertEquals(ScriptType.P2TR.getPublicKeyFromScript(script), keys.iterator().next(),
+                "the key a taproot spend signs against is the one in the output, not the one it was derived from");
+        Assertions.assertNotEquals(ECKey.fromPublicOnly(node.getPubKey()), keys.iterator().next(),
+                "the untweaked key would verify nothing");
+    }
+
+    /** A quorum vouches for every key in it, because any of them may be the one that signed. */
+    @Test
+    public void a_multisig_wallet_vouches_for_the_whole_quorum() throws Exception {
+        String[] mnemonics = {
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor",
+                "sample vibrant sound quantum ripple hidden pluck raven mirror ocean fabric noodle",
+                "vault cruise pistol trigger pilot scan hidden major fringe course fiber quiz"};
+
+        Wallet quorum = new Wallet();
+        quorum.setPolicyType(PolicyType.MULTI_HD);
+        quorum.setScriptType(ScriptType.P2WSH);
+        for(String mnemonic : mnemonics) {
+            DeterministicSeed seed = new DeterministicSeed(mnemonic, "", 0, DeterministicSeed.Type.BIP39);
+            quorum.getKeystores().add(Keystore.fromSeed(seed, PolicyType.MULTI_HD, ScriptType.P2WSH.getDefaultDerivation()));
+        }
+        quorum.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, ScriptType.P2WSH, quorum.getKeystores(), 2));
+        quorum.getNode(KeyPurpose.RECEIVE);
+        WalletNode node = quorum.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script script = quorum.getOutputScript(node);
+
+        Transaction transaction = new Transaction();
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90_000L, script);
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100_000L, script.getProgram()));
+
+        Set<ECKey> keys = AppServices.trustedKeys(psbtInput, quorum, node);
+        Assertions.assertEquals(3, keys.size(), "every key in the quorum can be the one that signed");
+        Assertions.assertTrue(keys.containsAll(node.getPubKeys()));
+    }
+
+    /**
+     * A derivation the PSBT supplies that this wallet cannot follow.
+     *
+     * A path naming this wallet's master fingerprint whose last element is hardened cannot be derived from a public
+     * key, and working out which inputs the wallet signs for reads those paths. Left unguarded it throws out of the
+     * count, which abandons the label mid update and leaves whatever it said before, and what it said before can be
+     * the confident green taken from an unsigned transaction's declaration.
+     */
+    @Test
+    public void a_derivation_this_wallet_cannot_follow_does_not_throw() throws Exception {
+        Script foreign = ScriptType.P2WPKH.getOutputScript(
+                ECKey.fromPrivate(com.sparrowwallet.drongo.Utils.hexToBytes("22".repeat(32))).getPubKey());
+        PSBTInput psbtInput = inputSpending(foreign);
+
+        List<ChildNumber> path = new java.util.ArrayList<>(wallet.getKeystores().get(0).getKeyDerivation().getDerivation());
+        path.add(new ChildNumber(0, false));
+        path.add(new ChildNumber(0, true));
+        psbtInput.getDerivedPublicKeys().put(ECKey.fromPrivate(com.sparrowwallet.drongo.Utils.hexToBytes("33".repeat(32))),
+                new KeyDerivation(wallet.getKeystores().get(0).getKeyDerivation().getMasterFingerprint(),
+                        KeyDerivation.writePath(path)));
+
+        int[] counts = Assertions.assertDoesNotThrow(() -> AppServices.signatureOptInCounts(lastPsbt, wallet),
+                "a derivation this wallet cannot follow must not leave the count");
+        Assertions.assertEquals(0, counts[0], "and nothing about it can be read as an opt-in");
+    }
+
+    /**
+     * A wallet built out of the PSBT is the case that matters most, because it looks like a wallet and vouches for
+     * nothing: it answers for the script with the PSBT's own output and for the keys with the ones the PSBT names, so
+     * every check would be the file agreeing with itself.
+     */
+    @Test
+    public void and_never_for_a_wallet_built_out_of_the_psbt() throws Exception {
+        PSBTInput psbtInput = inputSpending(wallet.getOutputScript(receiveNode));
+        //This wallet only exists for a PSBT that is already signed, which is exactly when the label is drawn for one
+        //that arrived from elsewhere
+        wallet.sign(lastPsbt);
+        Wallet finalizing = new FinalizingPSBTWallet(lastPsbt);
+
+        //The node this wallet itself answers with, which is what the counting passes in. Using the real wallet's node
+        //instead would be refused for disagreeing about the script, and would prove nothing about this wallet.
+        WalletNode finalizingNode = finalizing.getSigningNodes(lastPsbt).get(psbtInput);
+        Assertions.assertNotNull(finalizingNode, "this wallet must claim the input, or the case is not being exercised");
+        Assertions.assertEquals(finalizing.getOutputScript(finalizingNode), psbtInput.getUtxo().getScript(),
+                "its script check is the file agreeing with itself, which is what makes it worthless");
+
+        Assertions.assertTrue(AppServices.trustedKeys(psbtInput, finalizing, finalizingNode).isEmpty(),
+                "a wallet that reads its answers out of the PSBT must vouch for nothing");
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
@@ -27,6 +27,8 @@ import com.sparrowwallet.sparrow.wallet.SendController;
 import java.util.Arrays;
 import java.util.List;
 
+import java.util.ArrayList;
+
 /**
  * Whether a transaction being sent opts in to the unified signature hash.
  *
@@ -611,6 +613,79 @@ public class UnifiedSigHashPolicyTest {
      * than something the wallet has been shown to do, and the difference matters because a PSBT declaring a hash
      * type only some signers can produce is exactly the thing that could fail at finalisation.
      */
+    /**
+     * More signers than the quorum needs, where the one that opts in is the one finalising leaves out.
+     *
+     * A quorum is finalised by taking signatures in key order up to its threshold, so a 2-of-3 that collected three
+     * keeps two and discards the third. Where the discarded one is the only signature that opted in, the transaction
+     * that broadcasts carries no replay protection, and anything read before finalising said it did.
+     *
+     * The label is right about the result either way, which is why this documents the behaviour rather than failing
+     * on it: privkeyio/drongo#7 changes the choice, and is held back from this release because it changes multisig
+     * finalisation for every wallet while the label is honest without it.
+     */
+    @Test
+    public void testFinalisingCanDropTheOnlySignatureThatOptedIn() throws Exception {
+        String[] mnemonics = {
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor",
+                "sample vibrant sound quantum ripple hidden pluck raven mirror ocean fabric noodle",
+                "vault cruise pistol trigger pilot scan hidden major fringe course fiber quiz"};
+
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.MULTI_HD);
+        wallet.setScriptType(ScriptType.P2WSH);
+        for(String mnemonic : mnemonics) {
+            DeterministicSeed seed = new DeterministicSeed(mnemonic, "", 0, DeterministicSeed.Type.BIP39);
+            wallet.getKeystores().add(Keystore.fromSeed(seed, PolicyType.MULTI_HD, ScriptType.P2WSH.getDefaultDerivation()));
+        }
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, ScriptType.P2WSH, wallet.getKeystores(), 2));
+        wallet.getNode(KeyPurpose.RECEIVE);
+
+        WalletNode receiveNode = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script spk = wallet.getOutputScript(receiveNode);
+
+        //Finalising sorts by key, so the keystore whose key sorts last is the one that will be dropped
+        List<ECKey> ordered = new ArrayList<>(receiveNode.getPubKeys());
+        ordered.sort(new ECKey.LexicographicECKeyComparator());
+        ECKey droppedKey = ordered.get(ordered.size() - 1);
+        int droppedKeystore = receiveNode.getPubKeys().indexOf(droppedKey);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90000L, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().getFirst();
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100000L, spk.getProgram()));
+        psbtInput.setWitnessScript(ScriptType.MULTISIG.getOutputScript(2, receiveNode.getPubKeys()));
+
+        //Everyone signs, which a quorum of two does not need but nothing stops. Signed key by key rather than through
+        //Wallet.sign, which stops once the threshold is met and so would never produce the third signature.
+        //Only the one that finalising will drop opts in.
+        for(int i = 0; i < wallet.getKeystores().size(); i++) {
+            psbtInput.setSigHash(i == droppedKeystore ? SigHash.UNIFIED_ALL : SigHash.ALL);
+            Assertions.assertTrue(psbtInput.sign(wallet.getKeystores().get(i).getKey(receiveNode)),
+                    "keystore " + i + " did not sign");
+        }
+        psbtInput.setSigHash(SigHash.ALL);
+
+        Assertions.assertEquals(3, psbtInput.getPartialSignatures().size(), "all three must have signed");
+        Assertions.assertEquals(1, AppServices.signatureOptInCounts(psbt, wallet)[0],
+                "before finalising, one signature opts in");
+
+        wallet.finalise(psbt);
+
+        Assertions.assertEquals(0, AppServices.signatureOptInCounts(psbt, wallet)[0],
+                "finalising dropped the only signature that opted in, so nothing here is protected any more");
+        for(byte[] push : psbt.extractTransaction().getInputs().getFirst().getWitness().getPushes()) {
+            if(push.length >= 70 && push.length <= 73) {
+                Assertions.assertEquals((byte)0x01, push[push.length - 1],
+                        "the signatures that survived are the ones made the old way");
+            }
+        }
+    }
+
     @Test
     public void testAQuorumSignsAndFinalisesAnOptedInSpend() throws Exception {
         String[] mnemonics = {
@@ -652,6 +727,12 @@ public class UnifiedSigHashPolicyTest {
 
         wallet.sign(psbt);
         wallet.finalise(psbt);
+
+        //Finalising clears the witness script and the partial signatures, leaving the quorum's keys reachable only
+        //through what the final witness carries. The label is counted after this, so it has to still find them.
+        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt, wallet)[0],
+                "the finalised quorum's opted-in signatures were not counted");
+
         Transaction finalTx = psbt.extractTransaction();
 
         TransactionWitness witness = finalTx.getInputs().getFirst().getWitness();
@@ -959,7 +1040,7 @@ public class UnifiedSigHashPolicyTest {
         psbtInput.setSigHash(SigHash.UNIFIED_ALL);
 
         Assertions.assertTrue(psbtInput.getSigHash().isUnified(), "the declaration claims the opt-in");
-        Assertions.assertArrayEquals(new int[] {0, 1}, AppServices.signatureOptInCounts(psbt),
+        Assertions.assertArrayEquals(new int[] {0, 1, 1}, AppServices.signatureOptInCounts(psbt, wallet),
                 "but nothing signed opted in, so no protection may be reported");
     }
 
@@ -1006,7 +1087,7 @@ public class UnifiedSigHashPolicyTest {
         wallet.sign(psbt);
         wallet.getKeystores().getFirst().setSeed(first);
 
-        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt)[1], "both keys must have signed");
+        Assertions.assertEquals(2, AppServices.signatureOptInCounts(psbt, wallet)[2], "both keys must have signed");
         return AppServices.liftableSignatureCount(psbt);
     }
 
@@ -1077,7 +1158,7 @@ public class UnifiedSigHashPolicyTest {
         psbtInput.setWitnessUtxo(new TransactionOutput(null, 100000L, spk.getProgram()));
         psbtInput.setWitnessScript(ScriptType.MULTISIG.getOutputScript(2, receiveNode.getPubKeys()));
 
-        Assertions.assertArrayEquals(new int[] {0, 0}, AppServices.signatureOptInCounts(psbt), "nothing signed yet");
+        Assertions.assertArrayEquals(new int[] {0, 0, 0}, AppServices.signatureOptInCounts(psbt, wallet), "nothing signed yet");
 
         //One key signs the opted-in message, the other the legacy one, which is what per-device PSBTs produce
         DeterministicSeed second = wallet.getKeystores().get(1).getSeed();
@@ -1092,8 +1173,8 @@ public class UnifiedSigHashPolicyTest {
         wallet.sign(psbt);
         wallet.getKeystores().getFirst().setSeed(first);
 
-        int[] counts = AppServices.signatureOptInCounts(psbt);
-        Assertions.assertEquals(2, counts[1], "both keys signed");
+        int[] counts = AppServices.signatureOptInCounts(psbt, wallet);
+        Assertions.assertEquals(2, counts[2], "both keys signed");
         Assertions.assertEquals(1, counts[0], "exactly one of them opted in");
     }
 

--- a/src/test/java/com/sparrowwallet/sparrow/control/SweptKeyOptInTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/control/SweptKeyOptInTest.java
@@ -32,8 +32,13 @@ public class SweptKeyOptInTest {
         Assertions.assertEquals(SigHash.UNIFIED_ALL, psbtInput.getSigHash());
         Assertions.assertTrue(psbtInput.sign(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, privKey)));
 
-        int[] counts = AppServices.signatureOptInCounts(psbt);
-        Assertions.assertEquals(1, counts[1], "the key signed");
+        //The swept key is the whole of what there is to vouch for, since it belongs to no wallet. Read through the
+        //input itself rather than the wallet path, which has no wallet here to ask.
+        java.util.List<com.sparrowwallet.drongo.protocol.TransactionSignature> verified =
+                psbtInput.getVerifiedSignatures(java.util.List.of(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, privKey)));
+        int[] counts = new int[] {(int)verified.stream().filter(s -> (s.sighashFlags & SigHash.UNIFIED_FLAG) != 0).count(),
+                verified.size(), psbtInput.getSignatures().size()};
+        Assertions.assertEquals(1, counts[2], "the key signed");
         Assertions.assertEquals(1, counts[0], "and it opted in");
 
         //The signature has to verify against the digest its own byte names, or the node would refuse it
@@ -52,7 +57,9 @@ public class SweptKeyOptInTest {
         Assertions.assertNull(psbtInput.getSigHash(), "nothing declared, which signs the default");
         Assertions.assertTrue(psbtInput.sign(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, privKey)));
 
-        Assertions.assertEquals(0, AppServices.signatureOptInCounts(psbt)[0], "no signature opted in");
+        Assertions.assertTrue(psbt.getPsbtInputs().getFirst()
+                .getVerifiedSignatures(java.util.List.of(ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, privKey)))
+                .stream().noneMatch(s -> (s.sighashFlags & SigHash.UNIFIED_FLAG) != 0), "no signature opted in");
         psbt.verifySignatures();
     }
 

--- a/src/test/java/com/sparrowwallet/sparrow/transaction/OptInLabelRenderHarness.java
+++ b/src/test/java/com/sparrowwallet/sparrow/transaction/OptInLabelRenderHarness.java
@@ -1,0 +1,329 @@
+package com.sparrowwallet.sparrow.transaction;
+
+import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.policy.Policy;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import com.sparrowwallet.drongo.wallet.DeterministicSeed;
+import com.sparrowwallet.drongo.wallet.Keystore;
+import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.drongo.wallet.WalletNode;
+import com.sparrowwallet.sparrow.SparrowWallet;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5Brands;
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+import org.controlsfx.glyphfont.GlyphFontRegistry;
+
+import java.nio.file.Files;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * What the replay protection labels actually say once the transaction view has drawn them.
+ *
+ * OptInStatusTest covers the decision; this covers the wiring between that decision and the two labels a user reads,
+ * which no unit test can reach. Run it after changing either.
+ *
+ * A harness rather than a test because it needs a display, which the build does not have.
+ */
+public class OptInLabelRenderHarness {
+    private static Wallet wallet() throws Exception {
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.SINGLE_HD);
+        wallet.setScriptType(ScriptType.P2WPKH);
+        DeterministicSeed seed = new DeterministicSeed(
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor", "", 0, DeterministicSeed.Type.BIP39);
+        wallet.getKeystores().add(Keystore.fromSeed(seed, PolicyType.SINGLE_HD, ScriptType.P2WPKH.getDefaultDerivation()));
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.SINGLE_HD, ScriptType.P2WPKH, wallet.getKeystores(), null));
+        wallet.getNode(KeyPurpose.RECEIVE);
+        return wallet;
+    }
+
+    /**
+     * A 2 of 3 where one signer is marked and two are not, which is the wallet keystoreDecision answers
+     * OPTED_IN_IF_MARKED_SIGNS for: the two unmarked ones could form a quorum between them and that transaction would
+     * carry no opted-in signature. It is the ordinary partially marked multisig, and the label over it read
+     * "because null" until the caveat was used in place of a reason it has none of.
+     */
+    private static Wallet partiallyMarkedMultisig() throws Exception {
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(PolicyType.MULTI_HD);
+        wallet.setScriptType(ScriptType.P2WSH);
+
+        String[] words = {
+                "absent essay fox snake vast pumpkin height crouch silent bulb excuse razor",
+                "sell arrive brand fluid cousin twin trap bar hen fine bicycle rack",
+                "quantum lens tag pencil kingdom obey noise pigeon oyster shoulder ordinary tilt"};
+        for(int i = 0; i < words.length; i++) {
+            Keystore keystore = Keystore.fromSeed(new DeterministicSeed(words[i], "", 0, DeterministicSeed.Type.BIP39),
+                    PolicyType.MULTI_HD, ScriptType.P2WSH.getDefaultDerivation());
+            //A device rather than a seed this wallet holds: only then is its support the user's to state, and only
+            //then can a signer be unmarked
+            keystore.setSource(com.sparrowwallet.drongo.wallet.KeystoreSource.HW_USB);
+            keystore.setLabel("Signer " + (i + 1));
+            keystore.setUnifiedSigHashSupported(i == 0);
+            wallet.getKeystores().add(keystore);
+        }
+
+        wallet.setDefaultPolicy(Policy.getPolicy(PolicyType.MULTI_HD, ScriptType.P2WSH, wallet.getKeystores(), 2));
+        wallet.getNode(KeyPurpose.RECEIVE);
+        return wallet;
+    }
+
+    /** The same transaction before anything has signed it, which is where a declaration is all there is to read. */
+    private static PSBT unsignedPsbt(Wallet wallet, SigHash sigHash) throws Exception {
+        WalletNode node = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script spk = wallet.getOutputScript(node);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90_000L, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100_000L, spk.getProgram()));
+        psbtInput.setSigHash(sigHash);
+        for(Keystore keystore : wallet.getKeystores()) {
+            psbtInput.getDerivedPublicKeys().put(keystore.getPubKey(node),
+                    keystore.getKeyDerivation().extend(node.getDerivation()));
+        }
+
+        return psbt;
+    }
+
+    private static PSBT signedPsbt(Wallet wallet, SigHash sigHash) throws Exception {
+        WalletNode node = wallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+        Script spk = wallet.getOutputScript(node);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90_000L, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, 100_000L, spk.getProgram()));
+        psbtInput.setSigHash(sigHash);
+        psbtInput.getDerivedPublicKeys().put(node.getPubKey(), wallet.getKeystores().get(0).getKeyDerivation()
+                .extend(node.getDerivation()));
+        psbtInput.sign(wallet.getKeystores().get(0).getKey(node));
+
+        return psbt;
+    }
+
+    /** The labels as they stand on a view that has been built and had events delivered to it. */
+    private static String labelText(Node contents) {
+        Node node = contents.lookup("#signaturesOptIn");
+        if(!(node instanceof Label label)) {
+            return "(no label)";
+        }
+
+        //The glyph is half of what a user reads, and the mapping from level to glyph is asserted nowhere else
+        return label.getText() + (label.getGraphic() == null ? " (no glyph)"
+                : " [" + String.join(",", label.getGraphic().getStyleClass()) + "]");
+    }
+
+    /**
+     * The event layer, which is where the last two wrong readings lived: the label was computed once and then a later
+     * event changed the answer without it being read again. Built once, then driven the way the application drives it.
+     */
+    private static void driveEvents(Wallet wallet) throws Exception {
+        PSBT psbt = signedPsbt(wallet, SigHash.UNIFIED_ALL);
+        TransactionData data = new TransactionData("events", psbt);
+        data.setSigningWallet(wallet);
+        HeadersForm form = new HeadersForm(data);
+        Node contents = form.getContents();
+        new Scene((javafx.scene.Parent)contents);
+        ((Region)contents).resize(900, 700);
+        contents.applyCss();
+        ((Region)contents).layout();
+        System.out.println("  after building the view: \"" + labelText(contents) + "\"");
+
+        //Edited the way the view edits it, through the PSBT rather than the transaction it assembles on demand.
+        //Mutating that assembled transaction changes nothing, which is why an earlier version of this proved nothing.
+        psbt.setFallbackLocktime(psbt.getTransaction().getLocktime() + 5);
+        //Posted with the transaction the view holds, not a freshly assembled one: a PSBT builds a new object on every
+        //call and Transaction compares by identity, so the handler's own guard rejects anything else
+        com.sparrowwallet.sparrow.EventManager.get().post(
+                new com.sparrowwallet.sparrow.event.TransactionChangedEvent(data.getTransaction()));
+        System.out.println("  after the transaction was edited: \"" + labelText(contents) + "\"");
+
+        //A combine arrives carrying nothing this wallet can vouch for
+        for(PSBTInput psbtInput : psbt.getPsbtInputs()) {
+            psbtInput.getPartialSignatures().clear();
+        }
+        com.sparrowwallet.sparrow.EventManager.get().post(new com.sparrowwallet.sparrow.event.PSBTCombinedEvent(psbt));
+        System.out.println("  after a combine that removed the signatures: \"" + labelText(contents) + "\"");
+    }
+
+    private static void render(String name, PSBT psbt, Wallet signingWallet) throws Exception {
+        TransactionData data = new TransactionData(name, psbt);
+        data.setSigningWallet(signingWallet);
+        HeadersForm form = new HeadersForm(data);
+        Node contents = form.getContents();
+        new Scene((javafx.scene.Parent)contents);
+        ((Region)contents).resize(900, 700);
+        contents.applyCss();
+        ((Region)contents).layout();
+
+        for(String id : new String[] {"#signingWalletOptIn", "#signaturesOptIn"}) {
+            Node node = contents.lookup(id);
+            if(node instanceof Label label) {
+                System.out.println("  " + name + " " + id + " -> \"" + label.getText() + "\""
+                        + (label.getGraphic() == null ? " (no glyph)" : " [" + String.join(",", label.getGraphic().getStyleClass()) + "]")
+                        + (label.getTooltip() == null ? "" : System.lineSeparator()
+                            + "      tooltip: " + label.getTooltip().getText()));
+            }
+        }
+    }
+
+    private static volatile boolean failed;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty(SparrowWallet.APP_HOME_PROPERTY, Files.createTempDirectory("shrike-render").toString());
+        Network.set(Network.MAINNET);
+
+        CountDownLatch done = new CountDownLatch(1);
+        Platform.startup(() -> {
+            try {
+                GlyphFontRegistry.register(new FontAwesome5());
+                GlyphFontRegistry.register(new FontAwesome5Brands());
+                //The view asks the application for the wallets that are open, so there has to be one to ask
+                com.sparrowwallet.sparrow.AppServices.initialize(null);
+
+                Wallet wallet = wallet();
+                render("opted-in, wallet present", signedPsbt(wallet, SigHash.UNIFIED_ALL), wallet);
+                render("legacy, wallet present", signedPsbt(wallet, SigHash.ALL), wallet);
+                render("opted-in, no wallet to vouch", signedPsbt(wallet, SigHash.UNIFIED_ALL), null);
+
+                //A PSBT carrying a derivation this wallet cannot follow, on an input it does own. The input is found
+                //by its script, so the derivation is never consulted and the honest answer stands: the guard around
+                //that lookup must not cost a transaction its reading. Where the lookup does throw, the labels fall
+                //back to saying nothing was checked, which is what the fail closed path in updateOptInStatus is for.
+                PSBT undrivable = signedPsbt(wallet, SigHash.UNIFIED_ALL);
+                java.util.List<com.sparrowwallet.drongo.crypto.ChildNumber> path =
+                        new java.util.ArrayList<>(wallet.getKeystores().get(0).getKeyDerivation().getDerivation());
+                path.add(new com.sparrowwallet.drongo.crypto.ChildNumber(0, false));
+                path.add(new com.sparrowwallet.drongo.crypto.ChildNumber(0, true));
+                undrivable.getPsbtInputs().get(0).getDerivedPublicKeys().put(
+                        com.sparrowwallet.drongo.crypto.ECKey.fromPrivate(
+                                com.sparrowwallet.drongo.Utils.hexToBytes("33".repeat(32))),
+                        new com.sparrowwallet.drongo.KeyDerivation(
+                                wallet.getKeystores().get(0).getKeyDerivation().getMasterFingerprint(),
+                                com.sparrowwallet.drongo.KeyDerivation.writePath(path)));
+                render("opted-in, junk derivation attached to its own input", undrivable, wallet);
+
+                //Finalised, declaring the opt-in, and carrying nothing that reads as a signature. Nothing has been
+                //checked, so the file's own declaration must not come back as a promise.
+                PSBT finalisedJunk = signedPsbt(wallet, SigHash.UNIFIED_ALL);
+                for(PSBTInput psbtInput : finalisedJunk.getPsbtInputs()) {
+                    psbtInput.getPartialSignatures().clear();
+                    byte[] pubKeyShaped = new byte[33];
+                    java.util.Arrays.fill(pubKeyShaped, (byte)0x11);
+                    pubKeyShaped[0] = 0x02;
+                    psbtInput.setFinalScriptWitness(new com.sparrowwallet.drongo.protocol.TransactionWitness(
+                            null, java.util.List.of(pubKeyShaped)));
+                }
+                render("finalised, declares the opt-in, nothing readable", finalisedJunk, wallet);
+                render("finalised, declares the opt-in, no wallet", finalisedJunk, null);
+
+                //Nothing signed, and the wallet cannot promise the declaration survives: two unmarked signers could
+                //form the quorum between them. The condition is what this case has to say, and it has no reason.
+                Wallet multisig = partiallyMarkedMultisig();
+                render("unsigned, declares the opt-in, partially marked 2 of 3", unsignedPsbt(multisig, SigHash.UNIFIED_ALL), multisig);
+
+                //Every signer marked, so the declaration will survive whoever signs. What is left to say belongs to
+                //the chain, and it is said separately rather than folded into a sentence about the signers.
+                Wallet marked = partiallyMarkedMultisig();
+                marked.getKeystores().forEach(keystore -> keystore.setUnifiedSigHashSupported(true));
+                render("unsigned, declares the opt-in, every signer marked", unsignedPsbt(marked, SigHash.UNIFIED_ALL), marked);
+
+                render("unsigned, declares the opt-in, no wallet to ask", unsignedPsbt(multisig, SigHash.UNIFIED_ALL), null);
+
+                //Signed by a taproot script path and nothing else, declaring the opt-in. Those signatures were
+                //dropped at parse, so this looked unsigned and the label reported the declaration as what the
+                //transaction would be. It is signed, and nothing in it has been checked.
+                render("signed by a taproot script path only, declares the opt-in",
+                        com.sparrowwallet.sparrow.TapScriptSignedTest.signedByScriptPath(
+                                com.sparrowwallet.drongo.protocol.SigHash.ALL.byteValue()), wallet);
+
+                //One input asks for the opt-in and another does not. A PSBT from elsewhere can declare it on an input
+                //this wallet will never sign and the old type on the ones it will, so every input has to declare it
+                //before the transaction can be said to.
+                Wallet mixedWallet = wallet();
+                WalletNode mixedNode = mixedWallet.getNode(KeyPurpose.RECEIVE).getChildren().iterator().next();
+                Script mixedSpk = mixedWallet.getOutputScript(mixedNode);
+
+                //Built with both inputs from the start. A PSBT rebuilds its transaction on every call, so adding an
+                //input to the one it hands back adds it to a throwaway and the fixture quietly stays single input.
+                Transaction mixedTransaction = new Transaction();
+                mixedTransaction.setVersion(2);
+                mixedTransaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+                mixedTransaction.addInput(Sha256Hash.ZERO_HASH, 1, new Script(new byte[0]));
+                mixedTransaction.addOutput(90_000L, mixedSpk);
+
+                PSBT mixed = new PSBT(mixedTransaction);
+                if(mixed.getPsbtInputs().size() != 2) {
+                    throw new IllegalStateException("the mixed fixture must carry two inputs, not " + mixed.getPsbtInputs().size());
+                }
+                for(int i = 0; i < mixed.getPsbtInputs().size(); i++) {
+                    PSBTInput psbtInput = mixed.getPsbtInputs().get(i);
+                    psbtInput.setWitnessUtxo(new TransactionOutput(null, 100_000L, mixedSpk.getProgram()));
+                    psbtInput.setSigHash(i == 0 ? SigHash.UNIFIED_ALL : SigHash.ALL);
+                }
+                render("unsigned, one input asks for the opt-in and one does not", mixed, mixedWallet);
+
+                //A wallet that holds none of these keys. Nothing can be vouched for, so nothing may be reported as
+                //checked, however confident the file's own declaration is.
+                Wallet stranger = new Wallet();
+                stranger.setPolicyType(PolicyType.SINGLE_HD);
+                stranger.setScriptType(ScriptType.P2WPKH);
+                stranger.getKeystores().add(Keystore.fromSeed(new DeterministicSeed(
+                        "sell arrive brand fluid cousin twin trap bar hen fine bicycle rack", "", 0,
+                        DeterministicSeed.Type.BIP39), PolicyType.SINGLE_HD, ScriptType.P2WPKH.getDefaultDerivation()));
+                stranger.setDefaultPolicy(Policy.getPolicy(PolicyType.SINGLE_HD, ScriptType.P2WPKH,
+                        stranger.getKeystores(), null));
+                stranger.getNode(KeyPurpose.RECEIVE);
+                render("opted-in, but the open wallet holds none of these keys", signedPsbt(wallet(), SigHash.UNIFIED_ALL), stranger);
+
+                //The mapping from level to mark, which no unit test can assert because a glyph needs a display, and
+                //which nothing else covers: swapped, a green tick sits over "Not replay protected"
+                for(Object[] pair : new Object[][] {
+                        {HeadersController.OptInLevel.PROTECTED, "success"},
+                        {HeadersController.OptInLevel.UNPROTECTED, "warn-icon"},
+                        {HeadersController.OptInLevel.UNCHECKED, "question-icon"}}) {
+                    String actual = String.join(",", HeadersController.glyphFor((HeadersController.OptInLevel)pair[0]).getStyleClass());
+                    if(!actual.contains((String)pair[1])) {
+                        throw new IllegalStateException(pair[0] + " takes the wrong mark: " + actual);
+                    }
+                }
+                System.out.println("  level to mark: each of the three takes its own");
+
+                System.out.println("driving events through a built view:");
+                driveEvents(wallet());
+            } catch(Throwable t) {
+                System.out.println("RENDER FAILED: " + t);
+                t.printStackTrace(System.out);
+                failed = true;
+            } finally {
+                done.countDown();
+            }
+        });
+        done.await();
+        Platform.exit();
+        //Non zero, or a run that threw halfway reads as a clean one to whoever is looking at the output
+        System.exit(failed ? 1 : 0);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/transaction/OptInStatusTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/transaction/OptInStatusTest.java
@@ -1,0 +1,291 @@
+package com.sparrowwallet.sparrow.transaction;
+
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.sparrow.UnifiedSigHashDecision;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every state the replay protection label can be in, and the sentence each one puts in front of a user.
+ *
+ * The counts behind it are checked elsewhere, against transactions a node mined. What is checked here is what those
+ * counts are turned into, because the counts are not what anyone reads. Three of these cases were wrong at some point
+ * while this was being written, and none of them was caught by counting.
+ */
+public class OptInStatusTest {
+    /**
+     * The fixtures below take nothing signed to mean no signature present, which is true of them and is a convention
+     * of this test rather than a rule of the code. Production asks the PSBT instead, because a finalised input
+     * carrying nothing signature shaped counts zero signatures and is not unsigned; SignedStateTest covers that.
+     */
+    private HeadersController.OptInStatus status(SigHash declared, int optedIn, int verified, int signatures, int liftable) {
+        boolean declaresUnified = declared != null && declared.isUnified();
+        return optInStatus(declaresUnified, declaresUnified, true, signatures == 0, null,
+                optedIn, verified, signatures, liftable);
+    }
+
+    private static HeadersController.OptInStatus optInStatus(boolean everyInputDeclaresUnified, boolean anyInputDeclaresUnified,
+                                                             boolean willBeHonoured, boolean nothingSigned,
+                                                             UnifiedSigHashDecision decision, int optedInSignatures,
+                                                             int verifiedSignatures, int signatures, int liftable) {
+        return HeadersController.optInStatus(everyInputDeclaresUnified, anyInputDeclaresUnified, willBeHonoured,
+                nothingSigned, decision, java.util.List.of(), optedInSignatures, verifiedSignatures, signatures, liftable);
+    }
+
+    /**
+     * Nothing signed yet, so the declared type is all there is to go on, and a declaration is not a check. A PSBT from
+     * elsewhere writes its own declarations, so the settled wording and the success mark are not available here.
+     */
+    @Test
+    public void an_unsigned_transaction_says_what_it_will_be_rather_than_what_it_is() {
+        HeadersController.OptInStatus unified = status(SigHash.UNIFIED_ALL, 0, 0, 0, 0);
+        Assertions.assertEquals(HeadersController.OptInLevel.UNCHECKED, unified.level(),
+                "nothing has been checked, so this cannot carry the settled mark");
+        Assertions.assertEquals("Will be replay protected", unified.summary());
+        Assertions.assertFalse(unified.optedIn());
+
+        HeadersController.OptInStatus legacy = status(SigHash.ALL, 0, 0, 0, 0);
+        Assertions.assertFalse(legacy.optedIn());
+        Assertions.assertEquals("Will not be replay protected", legacy.summary());
+        Assertions.assertTrue(legacy.detail().startsWith("These signatures will be made the way they always have been."),
+                "nothing is signed yet, so this describes what the transaction will be rather than what it is");
+
+        Assertions.assertEquals("Will not be replay protected", status(null, 0, 0, 0, 0).summary(),
+                "a transaction declaring nothing has not opted in");
+        Assertions.assertFalse(optInStatus(false, false, true, true, null, 0, 0, 0, 0).optedIn(),
+                "an unsigned transaction where any input declares the old type has not opted in");
+    }
+
+    /**
+     * A declaration is worth what the signer will honour, and this wallet strips the opt-in on the way to a device it
+     * was not told supports it. Promising protection that the next step removes is the worst of both: it reads as
+     * settled, and it is contradicted by the wallet itself a moment later.
+     */
+    @Test
+    public void a_declaration_a_signer_may_not_honour_is_said_conditionally() {
+        HeadersController.OptInStatus honoured = optInStatus(true, true, true, true, null, 0, 0, 0, 0);
+        Assertions.assertEquals("Will be replay protected", honoured.summary());
+
+        HeadersController.OptInStatus maybe = optInStatus(true, true, false, true, null, 0, 0, 0, 0);
+        Assertions.assertEquals(HeadersController.OptInLevel.UNCHECKED, maybe.level());
+        Assertions.assertEquals("Replay protected only if the signer opts in", maybe.summary());
+        Assertions.assertTrue(maybe.detail().contains("Open this transaction with the wallet that holds the keys"),
+                "a conditional answer has to say what would settle it");
+    }
+
+    /**
+     * An unsigned transaction that will not opt in is a settled answer, not an unknown, and takes the warning mark
+     * rather than the question mark.
+     */
+    @Test
+    public void an_unsigned_transaction_that_will_not_opt_in_is_a_settled_negative() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 0, 0, 0, 0);
+
+        Assertions.assertEquals(HeadersController.OptInLevel.UNPROTECTED, status.level());
+        Assertions.assertEquals("Will not be replay protected", status.summary());
+    }
+
+    /**
+     * Something signed, and nothing on it could be read as a signature. That is not the unsigned case, and the file's
+     * own declaration is not evidence: it wrote that itself.
+     */
+    @Test
+    public void signed_but_unreadable_is_not_read_as_unsigned() {
+        HeadersController.OptInStatus status =
+                optInStatus(true, true, true, false, null, 0, 0, 0, 0);
+
+        Assertions.assertEquals(HeadersController.OptInLevel.UNCHECKED, status.level());
+        Assertions.assertEquals("Replay protection not checked", status.summary());
+        Assertions.assertTrue(status.detail().contains("could not be read"));
+        Assertions.assertFalse(status.detail().contains("will not be replayable"),
+                "a declaration this could not check must not be repeated as a promise");
+    }
+
+    /** One signature, checked, and it opts in. */
+    @Test
+    public void a_signature_that_opts_in_is_reported_as_protection() {
+        HeadersController.OptInStatus status = status(SigHash.UNIFIED_ALL, 1, 1, 1, 0);
+
+        Assertions.assertEquals(HeadersController.OptInLevel.PROTECTED, status.level());
+        Assertions.assertTrue(status.optedIn());
+        Assertions.assertEquals("Replay protected", status.summary());
+        Assertions.assertTrue(status.detail().contains("cannot be replayed"));
+        Assertions.assertTrue(status.detail().contains("each commits to the amount it spends"));
+    }
+
+    /**
+     * The case a stock signer produces, and the one that made this test exist. The signature was checked and is simply
+     * the old kind, so this knows how it was made and must not say it could not be read.
+     */
+    @Test
+    public void a_signature_checked_and_found_legacy_is_stated_plainly() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 0, 1, 1, 0);
+
+        Assertions.assertFalse(status.optedIn());
+        Assertions.assertEquals(HeadersController.OptInLevel.UNPROTECTED, status.level(),
+                "every signature present was checked, so this is a finding and not a gap");
+        Assertions.assertEquals("Not replay protected", status.summary());
+        Assertions.assertEquals("These signatures are made the way they always have been. They carry no replay protection.",
+                status.detail());
+        Assertions.assertFalse(status.detail().contains("could not be"),
+                "the signature was checked, so nothing here is unknown to this wallet");
+    }
+
+    /**
+     * And the case that is genuinely unknown: something present could not be checked at all. No wallet to vouch for the
+     * keys yet, an input this wallet does not derive, or a push that is not a signature all arrive here.
+     */
+    @Test
+    public void something_that_could_not_be_checked_is_hedged() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 0, 1, 2, 0);
+
+        Assertions.assertFalse(status.optedIn());
+        Assertions.assertTrue(status.detail().startsWith("Not all of these signatures could be checked"),
+                "what could not be read must not be reported as though it had been");
+        Assertions.assertTrue(status.detail().contains("no replay protection"));
+    }
+
+    /**
+     * A mixed witness, which is the shape the fork produces where one cosigner is marked and another is not. One
+     * opted-in signature protects the transaction; the rest are named for what they are.
+     */
+    @Test
+    public void a_mixed_witness_names_both_halves() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 1, 2, 2, 0);
+
+        Assertions.assertTrue(status.optedIn());
+        Assertions.assertEquals("Replay protected", status.summary());
+        Assertions.assertTrue(status.detail().contains("1 of 2 does"), "a count of one reads as one");
+        Assertions.assertTrue(status.detail().contains("The other one was made the old way"),
+                "both signatures were checked, so neither is unknown, and one of them reads as one");
+        Assertions.assertFalse(status.detail().contains("could not be confirmed"));
+    }
+
+    /** The same, where one of the others could not be checked. */
+    @Test
+    public void and_hedges_the_half_it_could_not_read() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 1, 2, 3, 0);
+
+        Assertions.assertTrue(status.optedIn());
+        Assertions.assertTrue(status.detail().contains("1 of 3 does"));
+        Assertions.assertTrue(status.detail().contains("The other 2 could not be confirmed as opting in"));
+    }
+
+    /**
+     * A legacy Anyone Can Pay signature beside an opted-in one commits only to its own input and the outputs, so it can
+     * be lifted out and spent where the fork was never adopted. The transaction is protected and that input is not.
+     */
+    @Test
+    public void a_liftable_signature_is_called_out_even_though_the_transaction_is_protected() {
+        HeadersController.OptInStatus one = status(SigHash.ALL, 1, 2, 2, 1);
+        Assertions.assertTrue(one.optedIn());
+        Assertions.assertTrue(one.detail().contains("One of those signs Anyone Can Pay"));
+        Assertions.assertTrue(one.detail().contains("can be lifted into another transaction"));
+
+        HeadersController.OptInStatus two = status(SigHash.ALL, 1, 3, 3, 2);
+        Assertions.assertTrue(two.detail().contains("2 of those sign Anyone Can Pay"));
+    }
+
+    /**
+     * Nothing verified at all, which is what a signed transaction viewed without its wallet looks like, and what every
+     * transaction opened with no matching wallet looks like.
+     *
+     * The headline says it was not checked rather than that it was checked and found wanting, because one signature
+     * that opts in anywhere is enough and an unchecked one might be it. The detail must not imply this looked.
+     */
+    @Test
+    public void nothing_checkable_says_so_rather_than_implying_it_looked() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 0, 0, 2, 0);
+
+        Assertions.assertFalse(status.optedIn());
+        Assertions.assertEquals(HeadersController.OptInLevel.UNCHECKED, status.level());
+        Assertions.assertEquals("Replay protection not checked", status.summary(),
+                "saying it is not protected would state as a finding something this did not look at");
+        Assertions.assertTrue(status.detail().startsWith("None of these signatures could be checked against a key this wallet holds"));
+        Assertions.assertTrue(status.detail().contains("treat it as carrying no replay protection"),
+                "unknown is not an invitation to assume the good case");
+    }
+
+    /**
+     * Some checked, some not. One opted-in signature anywhere is enough, so an unchecked one leaves the question open:
+     * this is not entitled to say the transaction is unprotected either.
+     */
+    @Test
+    public void partly_checkable_is_also_unknown() {
+        HeadersController.OptInStatus status = status(SigHash.ALL, 0, 1, 2, 0);
+
+        Assertions.assertEquals(HeadersController.OptInLevel.UNCHECKED, status.level());
+        Assertions.assertEquals("Replay protection not checked", status.summary());
+        Assertions.assertTrue(status.detail().startsWith("Not all of these signatures could be checked"));
+        Assertions.assertTrue(status.detail().contains("one signature that opts in anywhere is enough"));
+    }
+
+    /**
+     * Every signature present opted in, which is the strongest thing this can say: the transaction cannot be replayed
+     * and every signature in it commits to the amount it spends.
+     */
+    @Test
+    public void every_signature_opting_in_earns_the_stronger_sentence() {
+        HeadersController.OptInStatus status = status(SigHash.UNIFIED_ALL, 2, 2, 2, 0);
+
+        Assertions.assertTrue(status.optedIn());
+        Assertions.assertTrue(status.detail().contains("each commits to the amount it spends"));
+        Assertions.assertFalse(status.detail().contains("The other"));
+    }
+
+    /**
+     * A partially marked quorum has no reason it would not opt in, because it would, given the right signers. What it
+     * has is the condition, and the condition lives in the caveat rather than the reason. Reading the reason produced
+     * the literal word null in a sentence shown to the user, in the ordinary case of a multisig with one marked signer.
+     */
+    @Test
+    public void a_partially_marked_quorum_states_the_condition_rather_than_a_reason() {
+        //The caveat arrives as a qualification because the caller has the wallet and so can name the marked signers,
+        //which is the half of it a reader can act on
+        HeadersController.OptInStatus status = HeadersController.optInStatus(true, true, false, true,
+                UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS,
+                java.util.List.of(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS.getCaveat() + " Those are: Signer 1."),
+                0, 0, 0, 0);
+
+        Assertions.assertEquals("Replay protected only if the signer opts in", status.summary());
+        Assertions.assertFalse(status.detail().contains("null"), status.detail());
+        Assertions.assertTrue(status.detail().contains("a quorum made up entirely of them would not opt in"),
+                "the condition the caveat states is the one thing this case has to say");
+        Assertions.assertTrue(status.detail().contains("Those are: Signer 1."),
+                "and naming who to reach for is the half of it a reader can act on");
+    }
+
+    /**
+     * And the same for every other decision, since a decision reaching here with nothing to say is exactly how the
+     * first one got through. None of them may put the word null in front of a user, and each has to end a sentence.
+     */
+    @Test
+    public void no_decision_renders_as_the_word_null() {
+        for(UnifiedSigHashDecision decision : UnifiedSigHashDecision.values()) {
+            HeadersController.OptInStatus status = optInStatus(true, true, false, true, decision, 0, 0, 0, 0);
+            Assertions.assertFalse(status.detail().contains("null"), decision + " renders null: " + status.detail());
+            Assertions.assertTrue(status.detail().endsWith(".") || status.detail().endsWith("in."),
+                    decision + " does not end a sentence: " + status.detail());
+        }
+    }
+
+    /**
+     * Some inputs ask for the opt-in and some do not, which is any externally assembled transaction: a co-signer's
+     * PSBT, a payjoin proposal, a coinjoin. One opted-in signature anywhere protects the whole transaction, so calling
+     * this settled and unprotected states as a finding something that depends on which inputs get signed.
+     */
+    @Test
+    public void a_transaction_where_only_some_inputs_ask_for_the_opt_in_is_not_settled() {
+        HeadersController.OptInStatus status = HeadersController.optInStatus(false, true, true, true, null,
+                java.util.List.of(), 0, 0, 0, 0);
+
+        Assertions.assertEquals(HeadersController.OptInLevel.UNCHECKED, status.level(),
+                "this is not a finding, it depends on which of these inputs are signed");
+        Assertions.assertEquals("Replay protection depends on which inputs are signed", status.summary());
+        Assertions.assertTrue(status.detail().contains("One signature that opts in anywhere protects the whole transaction"));
+
+        Assertions.assertEquals("Will not be replay protected",
+                HeadersController.optInStatus(false, false, true, true, null, java.util.List.of(), 0, 0, 0, 0).summary(),
+                "where no input asks for it, the answer really is settled");
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/transaction/SignedStateTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/transaction/SignedStateTest.java
@@ -1,0 +1,89 @@
+package com.sparrowwallet.sparrow.transaction;
+
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.protocol.TransactionWitness;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Whether anything has signed, which decides whether the label reports a declaration or a count.
+ *
+ * Read off the number of pushes that looked like signatures, a finalised input carrying nothing signature shaped
+ * counted zero and the label republished the file's own declaration as a settled promise. The predicate is asked of
+ * the PSBT instead, and it is asserted here rather than only by a harness, because every test in this branch would
+ * still pass with the old rule put back.
+ */
+public class SignedStateTest {
+    private static final String PRIVATE_KEY = "11".repeat(32);
+    private static final long VALUE = 100_000_000L;
+
+    private PSBT unsigned(SigHash sigHash) {
+        ECKey key = ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY));
+        Script spk = ScriptType.P2WPKH.getOutputScript(PolicyType.SINGLE_HD, key);
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(VALUE - 10_000, spk);
+
+        PSBT psbt = new PSBT(transaction);
+        PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
+        psbtInput.setWitnessUtxo(new TransactionOutput(null, VALUE, spk.getProgram()));
+        psbtInput.setSigHash(sigHash);
+
+        return psbt;
+    }
+
+    @Test
+    public void an_unsigned_transaction_has_nothing_signed() {
+        Assertions.assertTrue(HeadersController.nothingSigned(unsigned(SigHash.UNIFIED_ALL)));
+    }
+
+    @Test
+    public void a_partial_signature_counts() {
+        PSBT psbt = unsigned(SigHash.ALL);
+        Assertions.assertTrue(psbt.getPsbtInputs().get(0).sign(
+                ScriptType.P2WPKH.getOutputKey(PolicyType.SINGLE_HD, ECKey.fromPrivate(Utils.hexToBytes(PRIVATE_KEY)))));
+
+        Assertions.assertFalse(HeadersController.nothingSigned(psbt));
+    }
+
+    /**
+     * The case the old rule got wrong. Finalised, so it has been signed, and carrying one push that reads as nothing,
+     * so counting signature shaped pushes gives zero and the transaction looks untouched.
+     */
+    @Test
+    public void a_finalised_input_carrying_nothing_readable_is_still_signed() {
+        PSBT psbt = unsigned(SigHash.UNIFIED_ALL);
+        byte[] pubKeyShaped = new byte[33];
+        Arrays.fill(pubKeyShaped, (byte)0x11);
+        pubKeyShaped[0] = 0x02;
+        psbt.getPsbtInputs().get(0).setFinalScriptWitness(new TransactionWitness(null, List.of(pubKeyShaped)));
+
+        Assertions.assertFalse(HeadersController.nothingSigned(psbt),
+                "it is finalised, so something signed it, whatever the pushes read as");
+    }
+
+    /** And the taproot script path case, whose signatures were being dropped before they could be seen at all. */
+    @Test
+    public void an_input_signed_only_by_a_taproot_script_path_is_signed() throws Exception {
+        PSBT psbt = com.sparrowwallet.sparrow.TapScriptSignedTest.signedByScriptPath(SigHash.ALL.byteValue());
+
+        Assertions.assertEquals(1, psbt.getPsbtInputs().get(0).getTapScriptSignatures().size(),
+                "the fixture has to carry the signature, or this test proves nothing");
+        Assertions.assertFalse(HeadersController.nothingSigned(psbt));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/wallet/SendLabelRenderHarness.java
+++ b/src/test/java/com/sparrowwallet/sparrow/wallet/SendLabelRenderHarness.java
@@ -1,0 +1,146 @@
+package com.sparrowwallet.sparrow.wallet;
+
+import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.Network;
+import com.sparrowwallet.drongo.policy.Policy;
+import com.sparrowwallet.drongo.policy.PolicyType;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.wallet.DeterministicSeed;
+import com.sparrowwallet.drongo.wallet.Keystore;
+import com.sparrowwallet.drongo.wallet.KeystoreSource;
+import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.drongo.wallet.WalletNode;
+import com.sparrowwallet.drongo.wallet.WalletTransaction;
+import com.sparrowwallet.sparrow.SparrowWallet;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5Brands;
+import javafx.application.Platform;
+import javafx.scene.control.Label;
+import org.controlsfx.glyphfont.GlyphFontRegistry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * What the send screen's replay protection label actually says once rendered.
+ *
+ * SendOptInDetailTest covers the sentence. This covers the rest of what a user reads: the headline, the glyph, and
+ * whether the label offers the one action it can. The transaction view has the same harness, and every wrong reading
+ * found so far was found by rendering a state rather than by reading the code.
+ *
+ * A harness rather than a test because glyphs need a display.
+ */
+public class SendLabelRenderHarness {
+    private static Wallet wallet(PolicyType policyType, ScriptType scriptType, String[] words, int marked) throws Exception {
+        Wallet wallet = new Wallet();
+        wallet.setPolicyType(policyType);
+        wallet.setScriptType(scriptType);
+
+        for(int i = 0; i < words.length; i++) {
+            Keystore keystore = Keystore.fromSeed(new DeterministicSeed(words[i], "", 0, DeterministicSeed.Type.BIP39),
+                    policyType, scriptType.getDefaultDerivation());
+            if(marked >= 0) {
+                keystore.setSource(KeystoreSource.HW_USB);
+                keystore.setLabel("Signer " + (i + 1));
+                keystore.setUnifiedSigHashSupported(i < marked);
+            }
+            wallet.getKeystores().add(keystore);
+        }
+
+        wallet.setDefaultPolicy(Policy.getPolicy(policyType, scriptType, wallet.getKeystores(),
+                policyType == PolicyType.MULTI_HD ? 2 : null));
+        wallet.getNode(KeyPurpose.RECEIVE);
+        return wallet;
+    }
+
+    private static WalletTransaction walletTransaction(Wallet wallet) {
+        //A fixed script, since the label never looks at the outputs and a wallet with no policy cannot derive one
+        Script spk = ScriptType.P2WPKH.getOutputScript(com.sparrowwallet.drongo.crypto.ECKey.fromPrivate(
+                com.sparrowwallet.drongo.Utils.hexToBytes("11".repeat(32))).getPubKey());
+
+        Transaction transaction = new Transaction();
+        transaction.setVersion(2);
+        transaction.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[0]));
+        transaction.addOutput(90_000L, spk);
+        TransactionOutput output = transaction.getOutputs().get(0);
+
+        return new WalletTransaction(wallet, transaction, Collections.emptyList(), List.of(Collections.emptyMap()),
+                Collections.emptyList(), List.of(new WalletTransaction.Output(output)), 10_000L);
+    }
+
+    /** The production method, on the production field, so what is read back is what a user would see. */
+    private static void render(String name, Wallet wallet) throws Exception {
+        SendController controller = new SendController();
+        Label label = new Label();
+
+        Field field = SendController.class.getDeclaredField("optInStatus");
+        field.setAccessible(true);
+        field.set(controller, label);
+
+        Method render = SendController.class.getDeclaredMethod("renderOptInStatus", WalletTransaction.class);
+        render.setAccessible(true);
+        render.invoke(controller, wallet == null ? null : walletTransaction(wallet));
+
+        System.out.println("  " + name);
+        System.out.println("      \"" + label.getText() + "\""
+                + (label.getGraphic() == null ? " (no glyph)" : " [" + String.join(",", label.getGraphic().getStyleClass()) + "]")
+                + (label.getStyleClass().contains("actionable") ? " (actionable)" : "")
+                + (label.isVisible() ? "" : " (hidden)"));
+        if(label.getTooltip() != null) {
+            System.out.println("      tooltip: " + label.getTooltip().getText());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty(SparrowWallet.APP_HOME_PROPERTY, Files.createTempDirectory("shrike-send").toString());
+        Network.set(Network.MAINNET);
+
+        String[] one = {"absent essay fox snake vast pumpkin height crouch silent bulb excuse razor"};
+        String[] three = {one[0],
+                "sell arrive brand fluid cousin twin trap bar hen fine bicycle rack",
+                "quantum lens tag pencil kingdom obey noise pigeon oyster shoulder ordinary tilt"};
+
+        CountDownLatch done = new CountDownLatch(1);
+        Platform.startup(() -> {
+            try {
+                GlyphFontRegistry.register(new FontAwesome5());
+                GlyphFontRegistry.register(new FontAwesome5Brands());
+                com.sparrowwallet.sparrow.AppServices.initialize(null);
+
+                //A tip past the activation height, so the chain is settled and what varies is the keystores. Offline,
+                //every wallet answers "the chain cannot be seen from here" and none of the rest is reachable.
+                com.sparrowwallet.drongo.protocol.BlockHeader header = new com.sparrowwallet.drongo.protocol.BlockHeader(
+                        1, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH, null, 0, 0x207fffffL, 0);
+                Field headerV2 = com.sparrowwallet.drongo.protocol.BlockHeader.class.getDeclaredField("headerV2");
+                headerV2.setAccessible(true);
+                headerV2.setBoolean(header, true);
+                com.sparrowwallet.sparrow.AppServices.setAnnouncedTip(
+                        new com.sparrowwallet.sparrow.ChainTip(Network.get().getBlake2bHeight() + 10, header));
+
+                render("no transaction yet", null);
+                render("software seed, signs here", wallet(PolicyType.SINGLE_HD, ScriptType.P2WPKH, one, -1));
+                render("one device, not marked", wallet(PolicyType.SINGLE_HD, ScriptType.P2WPKH, one, 0));
+                render("one device, marked", wallet(PolicyType.SINGLE_HD, ScriptType.P2WPKH, one, 1));
+                render("2 of 3, one signer marked", wallet(PolicyType.MULTI_HD, ScriptType.P2WSH, three, 1));
+                render("2 of 3, every signer marked", wallet(PolicyType.MULTI_HD, ScriptType.P2WSH, three, 3));
+                render("wallet with no keystores", new Wallet());
+            } catch(Throwable t) {
+                System.out.println("RENDER FAILED: " + t);
+                t.printStackTrace(System.out);
+            } finally {
+                done.countDown();
+            }
+        });
+        done.await();
+        Platform.exit();
+        System.exit(0);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/wallet/SendOptInDetailTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/wallet/SendOptInDetailTest.java
@@ -1,0 +1,88 @@
+package com.sparrowwallet.sparrow.wallet;
+
+import com.sparrowwallet.sparrow.UnifiedSigHashDecision;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * The sentence the send screen puts in front of someone about to broadcast.
+ *
+ * The transaction view had this same shape written inline and it printed the literal word null, for the ordinary
+ * multisig with one marked signer, because a decision that carries a condition carries no reason. That bug was found
+ * by rendering every state rather than by reading the code, so this checks every state here too, on the screen where
+ * the decision to broadcast is actually taken.
+ */
+public class SendOptInDetailTest {
+    /** No decision may put the word null in front of a user, and each has to end a sentence. */
+    @Test
+    public void every_decision_reads_as_a_sentence() {
+        for(UnifiedSigHashDecision decision : UnifiedSigHashDecision.values()) {
+            String detail = SendController.optInDetail(decision, List.of());
+
+            Assertions.assertFalse(detail.contains("null"), decision + " renders null: " + detail);
+            Assertions.assertTrue(detail.endsWith("."), decision + " does not end a sentence: " + detail);
+            Assertions.assertFalse(detail.contains(", because ."), decision + " has an empty reason: " + detail);
+            Assertions.assertFalse(detail.isBlank(), decision + " says nothing at all");
+        }
+    }
+
+    /** A settled opt-in is the only state that may claim both properties. */
+    @Test
+    public void only_a_guaranteed_opt_in_claims_the_commitment_to_amounts() {
+        for(UnifiedSigHashDecision decision : UnifiedSigHashDecision.values()) {
+            String detail = SendController.optInDetail(decision, List.of());
+
+            if(!decision.isGuaranteed()) {
+                Assertions.assertFalse(detail.contains("each commits to the amount it spends"),
+                        decision + " is not settled, so it may not claim every signature commits to its amount");
+            }
+            if(!decision.isOptedIn()) {
+                Assertions.assertFalse(detail.contains("cannot be replayed"),
+                        decision + " does not opt in, so it may not claim protection");
+            }
+        }
+    }
+
+    /**
+     * A partially marked quorum is protected only if a marked signer is among those that sign, and says so. It carries
+     * no reason, which is exactly the state that broke the other screen.
+     */
+    @Test
+    public void a_partially_marked_quorum_states_its_condition() {
+        String detail = SendController.optInDetail(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS, List.of());
+
+        Assertions.assertFalse(detail.contains("null"), detail);
+        Assertions.assertTrue(detail.startsWith("This transaction cannot be replayed onto the SHA256d chain if one of the marked signers"));
+        Assertions.assertFalse(detail.contains("each commits to the amount it spends"),
+                "the unmarked signers commit to nothing, so this is not the settled sentence");
+    }
+
+    /**
+     * Every caveat, not only the one the headline came from. On an Electrum connection a partially marked multisig has
+     * two at once and only one of them can be the headline; the one dropped is the actionable one.
+     */
+    @Test
+    public void every_caveat_is_reported_whatever_the_headline_was() {
+        String detail = SendController.optInDetail(UnifiedSigHashDecision.OPTED_IN_IF_MARKED_SIGNS,
+                List.of("First caveat.", "Second caveat."));
+
+        Assertions.assertTrue(detail.contains("First caveat."));
+        Assertions.assertTrue(detail.contains("Second caveat."));
+    }
+
+    /**
+     * Caveats reach the states that decline too. A decision that would not opt in still has whatever the chain or the
+     * keystores had to add, and dropping it there was the asymmetry between the two screens.
+     */
+    @Test
+    public void a_declined_decision_still_reports_its_caveats_and_its_remedy() {
+        String detail = SendController.optInDetail(UnifiedSigHashDecision.EXTERNAL_SIGNER, List.of("A caveat."));
+
+        Assertions.assertTrue(detail.startsWith("These signatures will be made the way they always have been, because "));
+        Assertions.assertTrue(detail.contains("A caveat."));
+        Assertions.assertTrue(detail.contains(UnifiedSigHashDecision.EXTERNAL_SIGNER.getRemedy()),
+                "a state the user can act on has to say what to do");
+    }
+}


### PR DESCRIPTION
The transaction view could report **Replay protected** for a transaction carrying none: any 64 or 65 byte push decodes as a Schnorr signature whose hash type is its own last byte, so a control block, an uncompressed public key, or a partial signature a stranger added and finalising drops all counted as an opt-in. An opt-in now counts only where a signature verifies against a key this wallet derives, for an input whose spent output matches the script this wallet derives for that node. What could not be checked reads as not checked rather than as protected.

Proven against a Bitcoin Knots regtest node in `forged_optin_label.py`: the wallet counts no opt-in on a PSBT a stranger added an opted-in signature to, and the transaction it broadcasts is accepted by a node that never scheduled the fork, which is what not being protected means.

Needs privkeyio/drongo#5 and privkeyio/drongo#7, which this branch points at.
