### PR TITLE
Give the About text room to finish

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -586,7 +586,7 @@ public class AppController implements Initializable {
             controller.initializeView();
             setStageIcon(stage);
             stage.setOnShowing(event -> {
-                AppServices.moveToActiveWindowScreen(stage, 600, 460);
+                AppServices.moveToActiveWindowScreen(stage, 600, 500);
             });
 
             return stage;

--- a/src/main/resources/com/sparrowwallet/sparrow/about.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/about.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.*?>
 <?import com.sparrowwallet.sparrow.control.DialogImage?>
 
-<StackPane prefHeight="460.0" prefWidth="600.0" stylesheets="@about.css, @general.css" fx:controller="com.sparrowwallet.sparrow.AboutController" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml">
+<StackPane prefHeight="500.0" prefWidth="600.0" stylesheets="@about.css, @general.css" fx:controller="com.sparrowwallet.sparrow.AboutController" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml">
     <VBox spacing="20">
         <HBox styleClass="title-area">
             <HBox alignment="CENTER_LEFT">

--- a/src/test/java/com/sparrowwallet/sparrow/AboutLayoutHarness.java
+++ b/src/test/java/com/sparrowwallet/sparrow/AboutLayoutHarness.java
@@ -1,0 +1,65 @@
+package com.sparrowwallet.sparrow;
+
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+import org.controlsfx.glyphfont.GlyphFontRegistry;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5;
+import com.sparrowwallet.sparrow.glyphfont.FontAwesome5Brands;
+import java.util.concurrent.CountDownLatch;
+
+
+/**
+ * Whether every paragraph of the About dialog fits at the height the dialog opens at.
+ *
+ * A wrapped label given less height than its text needs is not laid out short, it is drawn with an ellipsis, so the
+ * text simply goes missing and nothing about the layout complains. That is what happened when a fourth paragraph was
+ * added: every one of them lost its last line. Run this after changing that text.
+ *
+ * A harness rather than a test because it needs a display, which the build does not have.
+ */
+public class AboutLayoutHarness {
+    public static void main(String[] args) throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        Platform.startup(() -> {
+            try {
+                GlyphFontRegistry.register(new FontAwesome5());
+                GlyphFontRegistry.register(new FontAwesome5Brands());
+                for(double height : new double[]{460, 480, 500, 520}) {
+                    FXMLLoader loader = new FXMLLoader(Class.forName("com.sparrowwallet.sparrow.AboutController").getResource("about.fxml"));
+                    Parent root = loader.load();
+                    new Scene(root);
+                    ((Region)root).resize(600, height);
+                    root.applyCss();
+                    root.layout();
+
+                    //A wrapped label that is shorter than the text needs is one that will be drawn with an ellipsis
+                    boolean truncated = false;
+                    double lastBottom = 0;
+                    for(Node node : root.lookupAll(".label")) {
+                        if(node instanceof Label label && label.isWrapText() && label.getText() != null && label.getText().length() > 40) {
+                            double needed = label.prefHeight(label.getWidth());
+                            if(label.getHeight() + 0.5 < needed) {
+                                truncated = true;
+                            }
+                            lastBottom = Math.max(lastBottom, label.localToScene(label.getBoundsInLocal()).getMaxY());
+                        }
+                    }
+                    System.out.println(String.format("%.0f high -> %s, text ends at y=%.0f", height,
+                            truncated ? "TRUNCATED" : "fits", lastBottom));
+                }
+            } catch(Throwable t) {
+                System.out.println("FAILED: " + t);
+            } finally {
+                done.countDown();
+            }
+        });
+        done.await();
+        Platform.exit();
+        System.exit(0);
+    }
+}


### PR DESCRIPTION
Every paragraph in About Shrike loses its last line, ending in an ellipsis. My doing: the pane's height is fixed at 460, and the fourth paragraph added in #21 pushed the content past it. A wrapped label given less height than its text needs is not laid out short, it is drawn truncated, so the text goes missing and nothing about the layout complains.

Rendered before, at 460:

```
Shrike is a Bitcoin wallet with the goal of providing greater transparency and usability on
the path to full financial self-sovereignty. It attempts to provide all of the detail about your
wallet setup, transactions and UTXOs so that you can transact with a full understanding ...

Shrike can operate in both an online and offline mode. In the online mode it connects to a
Bitcoin Knots node or Electrum server to display transaction history. In the offline mode ...
```

All four paragraphs end that way, including the one that says this is not a Sparrow release, which is the sentence with the most reason to be read in full.

## What changed

The pane opens at 500 rather than 460, and the positioning call that shadows that size follows it. Nothing else: no text, no styles, no wrapping attributes, which were correct all along.

## Verification

Measured rather than eyeballed. `AboutLayoutHarness` lays the dialog out at a range of heights and compares each wrapped label's height against the height its text needs at that width:

```
460 high -> TRUNCATED, text ends at y=354
480 high -> fits, text ends at y=365
500 high -> fits, text ends at y=365
520 high -> fits, text ends at y=365
```

480 is where it starts fitting; 500 leaves headroom, because font metrics differ across platforms and this was rendered on one of them. The harness is left in the tree for the next person to change that text, since the failure is silent. It is a harness rather than a test because it needs a display, which the build does not have.

Rendered again at 500, every paragraph reads to its end and the Close button sits clear of the text. Suite: 1061 tests, no failures.
