### PR TITLE
Frame the fork as a date the chain passed, not a side to join

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shrike
 
-Shrike is an unofficial fork of [Sparrow Bitcoin Wallet](https://github.com/sparrowwallet/sparrow) that follows the BLAKE2b proof-of-work hardfork of Bitcoin and signs with the unified opt-in signature hash. It is not affiliated with the Sparrow project. Upstream Sparrow has not adopted the fork, so use it instead if that is what you want.
+Shrike is an unofficial fork of [Sparrow Bitcoin Wallet](https://github.com/sparrowwallet/sparrow) that follows the BLAKE2b proof-of-work hardfork of Bitcoin and signs with the unified opt-in signature hash. It is not affiliated with the Sparrow project. Upstream Sparrow has not added support for it, so use it instead if that is what you want.
 
 > **Not audited. Use at your own risk, and no warranty of any kind, see the [Apache 2.0 license](LICENSE).** Everything below the divider is upstream's documentation and describes Sparrow rather than Shrike.
 
@@ -9,7 +9,7 @@ Shrike is an unofficial fork of [Sparrow Bitcoin Wallet](https://github.com/spar
 - **BLAKE2b proof of work.** Validates the 164 byte v2 block header and takes the BLAKE2b hash as the block id past activation. Implemented in the [drongo](https://github.com/privkeyio/drongo) submodule.
 - **Unified opt-in signature hash.** Signs with hash type `0x21` past activation, which is invalid under the pre-fork rules and is what makes it unreplayable. Where it cannot opt in, the wallet signs the legacy way and says so on the send screen.
 - **Per-keystore opt-in.** Nothing a device or a watch only keystore reports says what will sign for it, so each is marked by hand under Replay protection. A keystore holding its own key needs no mark. One marked signer is enough, and unmarked signers still sign: each is handed the hash type it can produce.
-- **Only services that have adopted the fork are offered.** Fee rates, explorer links and broadcast use mempool.guide; the preconfigured public Electrum servers are gone, because none of them have. Connect a Knots node, or your own Electrum server indexing one.
+- **Only services that kept up are offered.** Fee rates, explorer links and broadcast use mempool.guide; the preconfigured public Electrum servers are gone, because they stopped at the activation height. Connect a Knots node, or your own Electrum server indexing one.
 - **Separate application identity.** Installs alongside an existing Sparrow without sharing state: `~/.shrike`, its own packages, desktop entries, MIME types and macOS bundle identifier.
 
 ## Activation
@@ -23,7 +23,7 @@ The compiled-in height is cross checked against the connected node where it repo
 
 ## Replay protection
 
-A signature that does not opt in is valid under both rule sets, so it can be replayed against nodes that have not adopted the fork. **Check the send screen before building anything.** The opt-in is selected by default:
+A signature that does not opt in is valid under both rule sets, so it can be replayed against nodes still on the old rules. **Check the send screen before building anything.** The opt-in is selected by default:
 
 ![The send screen reporting a transaction as replay protected](docs/images/send-replay-protected.png)
 
@@ -37,9 +37,9 @@ Where a signer is the reason, tick it in the keystore tab of the wallet settings
 
 **In a multisig** one marked signer is enough. Mark two of a 2-of-3 and every transaction opts in; mark one and the opt-in depends on that signer taking part, which the wallet says rather than promising in advance.
 
-**The exception is Anyone Can Pay**, which commits only to its own input and the outputs, so that input can be lifted out and spent against nodes that have not adopted the fork, even though the transaction cannot. The send screen names such signatures. Shrike never selects it by itself.
+**The exception is Anyone Can Pay**, which commits only to its own input and the outputs, so that input can be lifted out and spent against nodes still on the old rules, even though the transaction cannot. The send screen names such signatures. Shrike never selects it by itself.
 
-Coins held across activation are only separated once spent with an opted-in signature, and a spend covers only the inputs it consumes, so sweep every pre-fork UTXO to yourself before transacting with nodes that have not adopted the fork.
+Coins held across activation are only separated once spent with an opted-in signature, and a spend covers only the inputs it consumes, so sweep every pre-fork UTXO to yourself before transacting with nodes still on the old rules.
 
 ## Building
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -1114,13 +1114,13 @@ public class AppServices {
 
     /**
      * How many signatures in this transaction can be lifted out of it and spent against nodes that have not
-     * adopted the fork.
+     * kept up.
      *
      * One opted-in signature makes the whole transaction invalid under the pre-fork rules, but the legacy signatures
      * inside it stay individually valid there. A legacy ALL or SINGLE signature commits to every input, so it is
      * useless in any other transaction. A legacy ANYONECANPAY one commits only to its own input and to the outputs,
      * so it can be copied into a transaction that drops the opted-in inputs and spent against a node that never
-     * adopted the fork. The transaction is protected; that input is not, and saying only "protected" would hide it.
+     * kept up. The transaction is protected; that input is not, and saying only "protected" would hide it.
      */
     public static int liftableSignatureCount(PSBT psbt) {
         if(psbt == null) {

--- a/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
+++ b/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
@@ -166,7 +166,7 @@ public enum UnifiedSigHashDecision {
      * What the signature does, in terms of the consequence rather than the hash type that carries it.
      *
      * The sighash control names the type already, and the byte is not what a person is deciding about:
-     * the choice is between a signature that cannot be replayed against nodes that have not adopted the
+     * the choice is between a signature that cannot be replayed against nodes still on the old rules
      * fork and commits to the amounts it spends, and one that predates both guarantees.
      */
     public String getSummary() {

--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -136,7 +136,7 @@ public class Config {
     /**
      * Corrects a stored server type that names an option this build no longer has.
      *
-     * No public Electrum server has adopted the fork. Left alone, a config written before the option was
+     * No public Electrum server kept up. Left alone, a config written before the option was
      * withdrawn connects to one at startup, from AppServices.start, well before any settings screen could
      * correct it, and shows blocks and balances that diverge past the activation height. Done once here
      * rather than in the accessor so that reading the type still returns what was set.

--- a/src/main/java/com/sparrowwallet/sparrow/net/BlockExplorer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/BlockExplorer.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 public enum BlockExplorer {
     /*
         mempool.guide is a mempool instance following the BLAKE2b fork. mempool.space and blockstream.info
-        were here and are gone: neither has adopted the fork, so a link to either for anything
+        were here and are gone: neither kept up, so a link to either for anything
         mined past the activation height names a block they do not have. A custom URL can still be entered
         in the settings for anyone who wants one.
      */

--- a/src/main/java/com/sparrowwallet/sparrow/net/BroadcastSource.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/BroadcastSource.java
@@ -18,11 +18,11 @@ import java.util.List;
 
 public enum BroadcastSource {
     /*
-        None of the sources that were here, blockstream.info, mempool.space and mempool.emzy.de, has adopted
-        the fork. This path replaces the connected node rather than supplementing it when a Tor proxy is
+        None of the sources that were here, blockstream.info, mempool.space and mempool.emzy.de, kept up.
+ This path replaces the connected node rather than supplementing it when a Tor proxy is
         configured, so broadcasting through one of them offered the transaction to nodes that have not
-        adopted the fork: an opted-in transaction is refused there, but a legacy one relays, which is the
-        replay this wallet exists to avoid. mempool.guide has adopted it and is the only source left.
+        kept up: an opted-in transaction is refused there, but a legacy one relays, which is the
+        replay this wallet exists to avoid. mempool.guide kept up and is the only source left.
      */
     MEMPOOL_GUIDE("mempool.guide", "https://mempool.guide", "http://mempool5nxspkxjk3n5afqh7zswbv4i324z76ltmw3cvfmniw45mnhad.onion") {
         public Sha256Hash broadcastTransaction(Transaction transaction) throws BroadcastException {

--- a/src/main/java/com/sparrowwallet/sparrow/net/FeeRatesSource.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/FeeRatesSource.java
@@ -28,7 +28,7 @@ public enum FeeRatesSource {
     },
     /*
         A mempool instance that follows the BLAKE2b fork, which is the reason for its presence here and is not
-        apparent from the name. It runs the same API as the instances that have not adopted the fork,
+        apparent from the name. It runs the same API as the instances that stopped at the activation height,
         so it differs from those only in the host it asks.
      */
     MEMPOOL_GUIDE("mempool.guide", true) {
@@ -142,10 +142,10 @@ public enum FeeRatesSource {
     /**
      * The source to use when the user has not chosen one.
      *
-     * mempool.space has not adopted the fork, so past the activation height it holds neither these blocks
+     * mempool.space stopped at the activation height, so past the activation height it holds neither these blocks
      * nor this mempool. Asking it for a block summary returns 404 for a block that exists, and asking it for
      * fee rates prices a transaction against a mempool this wallet is not broadcasting into. mempool.guide
-     * runs the same API and has adopted the fork, which is why it is the default here and not upstream.
+     * runs the same API and kept up, which is why it is the default here and not upstream.
      */
     public static FeeRatesSource getDefault() {
         return MEMPOOL_GUIDE;

--- a/src/main/java/com/sparrowwallet/sparrow/net/PublicElectrumServer.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/PublicElectrumServer.java
@@ -35,10 +35,10 @@ public enum PublicElectrumServer {
     }
 
     /*
-        Empty, so the public server option is never offered. No server listed above has adopted the fork, and
+        Empty, so the public server option is never offered. No server listed above kept up, and
         connecting to one would show this wallet blocks and balances that diverge past the activation height.
         That is worse than a stale fee or a dead explorer link: it is the whole wallet reading the wrong
-        history. Since there is no public server that has adopted the fork, the honest answer is to offer none
+        history. Since there is no public server that kept up, the honest answer is to offer none
         rather than one that misleads. Connect a Knots node, or a private Electrum server indexing it. The
         entries are left in place rather than deleted so that upstream changes to this file continue to merge.
      */

--- a/src/main/java/com/sparrowwallet/sparrow/terminal/settings/PublicElectrumDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/terminal/settings/PublicElectrumDialog.java
@@ -29,7 +29,7 @@ public class PublicElectrumDialog extends ServerProxyDialog {
 
         mainPanel.addComponent(new Label("URL"));
         url = new ComboBox<>();
-        //No public server has adopted the fork, so this list is empty and the dialog is not offered. Reachable
+        //No public server kept up, so this list is empty and the dialog is not offered. Reachable
         //only from a stored config naming the type from before it was withdrawn, and indexing an empty list
         //here would throw rather than say so.
         List<PublicElectrumServer> servers = PublicElectrumServer.getServers();

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1099,10 +1099,10 @@ public class HeadersController extends TransactionFormController implements Init
         if(everySignature || signatures == 0) {
             //"the amount it spends" rather than "the amounts they spend": an Anyone Can Pay signature commits to its
             //own input's amount and no other, so the blanket claim was not true of one.
-            return "These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and each commits to the amount it spends.";
+            return "These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes still on the old rules, and each commits to the amount it spends.";
         }
 
-        String detail = "This transaction cannot be replayed against nodes that have not adopted the fork: one signature that opts in is enough, and "
+        String detail = "This transaction cannot be replayed against nodes still on the old rules: one signature that opts in is enough, and "
                 + optedInSignatures + " of " + signatures + " do."
                 + System.lineSeparator() + System.lineSeparator()
                 + "The other " + (signatures - optedInSignatures) + " were made the way they always have been, so those signers were shown the amounts by this computer rather than committing to them.";
@@ -1112,8 +1112,8 @@ public class HeadersController extends TransactionFormController implements Init
         //protected either way, so this is the one case where the headline is true and still not the whole answer.
         if(liftable > 0) {
             detail += System.lineSeparator() + System.lineSeparator()
-                    + (liftable == 1 ? "One of those signs Anyone Can Pay, so it commits only to its own input and to the outputs. That input alone can be lifted into another transaction and spent against nodes that have not adopted the fork, paying these same outputs."
-                                     : liftable + " of those sign Anyone Can Pay, so each commits only to its own input and to the outputs. Those inputs can be lifted into another transaction and spent against nodes that have not adopted the fork, paying these same outputs.")
+                    + (liftable == 1 ? "One of those signs Anyone Can Pay, so it commits only to its own input and to the outputs. That input alone can be lifted into another transaction and spent against nodes still on the old rules, paying these same outputs."
+                                     : liftable + " of those sign Anyone Can Pay, so each commits only to its own input and to the outputs. Those inputs can be lifted into another transaction and spent against nodes still on the old rules, paying these same outputs.")
                     + " Have those signers opt in too, or sign the whole transaction with All, to close that.";
         }
 

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1152,7 +1152,7 @@ public class SendController extends WalletFormController implements Initializabl
 
         StringBuilder detail = new StringBuilder();
         if(decision.isOptedIn()) {
-            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes that have not adopted the fork, and each commits to the amount it spends.");
+            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes still on the old rules, and each commits to the amount it spends.");
             //Every caveat that applies, not only the one the headline came from: on an Electrum connection a
             //partially marked multisig has two, and the one the headline dropped is the actionable one
             for(String caveat : status.caveats()) {

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/keystore.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/keystore.fxml
@@ -114,7 +114,7 @@
             </Field>
             <Field fx:id="unifiedSigHashField" text="Replay protection:">
                 <CheckBox fx:id="unifiedSigHash" text="I confirm this device supports it" />
-                <HelpLabel helpText="Whether the signer behind this keystore produces the unified opt-in signature hash.\nA device reports its model but not its firmware, and a watch only keystore says nothing about what signs for it, so only you can say.\n\nLeave this off if you are unsure. A signature that does not opt in is valid under the pre-fork rules as well as the new ones, so it can be replayed against nodes that have not adopted the fork.\n\nTurning it on for a device that does not support it does not fall back: the device signs nothing and reports a failure of its own." />
+                <HelpLabel helpText="Whether the signer behind this keystore produces the unified opt-in signature hash.\nA device reports its model but not its firmware, and a watch only keystore says nothing about what signs for it, so only you can say.\n\nLeave this off if you are unsure. A signature that does not opt in is valid under the pre-fork rules as well as the new ones, so it can be replayed against nodes still on the old rules.\n\nTurning it on for a device that does not support it does not fall back: the device signs nothing and reports a failure of its own." />
             </Field>
         </Fieldset>
     </Form>

--- a/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/UnifiedSigHashPolicyTest.java
@@ -903,7 +903,7 @@ public class UnifiedSigHashPolicyTest {
      * Counted off the signatures, and only the ones that can actually be lifted. An opted-in ANYONECANPAY signature is
      * invalid under the pre-fork rules to begin with, and a legacy ALL commits to every input, so neither counts.
      * Proven against a node in anyonecanpay_lift.py, where the lifted signature was mined by a node that had
-     * not adopted the fork.
+     * stopped at the activation height.
      */
     @Test
     public void testOnlyALegacyAnyonecanpaySignatureIsCountedAsLiftable() throws Exception {

--- a/src/test/java/com/sparrowwallet/sparrow/io/StoredServerTypeTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/io/StoredServerTypeTest.java
@@ -12,8 +12,8 @@ import java.lang.reflect.Field;
  *
  * Nothing sanitized the stored type at load. Config.getServer reads it and returns the stored public server,
  * and the connection is made from AppServices.start, which runs before any settings screen could correct it.
- * So an upgrading user who was on a public server would have silently connected to one that has not adopted
- * the fork, which is the whole wallet reading the wrong history rather than one stale number.
+ * So an upgrading user who was on a public server would have silently connected to one that stopped at the
+ * activation height, which is the whole wallet reading the wrong history rather than one stale number.
  */
 public class StoredServerTypeTest {
     private Config configWith(ServerType stored, Server core, Server electrum) throws Exception {
@@ -44,7 +44,7 @@ public class StoredServerTypeTest {
         Server core = new Server("http://127.0.0.1:8332");
         Assertions.assertEquals(ServerType.BITCOIN_CORE,
                 migrated(configWith(ServerType.PUBLIC_ELECTRUM_SERVER, core, null)),
-                "a node is configured, so use it rather than a public server that has not adopted the fork");
+                "a node is configured, so use it rather than a public server that stopped at the activation height");
 
         Server electrum = new Server("ssl://127.0.0.1:50002");
         Assertions.assertEquals(ServerType.ELECTRUM_SERVER,

--- a/src/test/java/com/sparrowwallet/sparrow/net/FeeRatesSourceDefaultTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/FeeRatesSourceDefaultTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * The default source has to be one that has adopted the fork.
+ * The default source has to be one that kept up.
  *
- * mempool.space has not adopted the fork. Past the activation height it holds neither this wallet's blocks
+ * mempool.space stayed on the old rules, so past the activation height it holds neither this wallet's blocks
  * nor its mempool, so it answers 404 for a block that exists and prices transactions against a mempool
  * this wallet never broadcasts into. Both were reached with the source left unset, which is the state every
  * new install starts in, so the default is the thing worth pinning.
@@ -16,7 +16,7 @@ public class FeeRatesSourceDefaultTest {
     @Test
     public void testTheDefaultHasAdoptedTheFork() {
         Assertions.assertEquals(FeeRatesSource.MEMPOOL_GUIDE, FeeRatesSource.getDefault(),
-                "the default must be a source that has adopted the fork");
+                "the default must be a source that kept up");
     }
 
     @Test
@@ -52,7 +52,7 @@ public class FeeRatesSourceDefaultTest {
 
     /**
      * The explorer a transaction link opens has the same requirement. Neither mempool.space nor
-     * blockstream.info has adopted the fork, so a link to either names a block they do not have once the
+     * blockstream.info kept up, so a link to either names a block they do not have once the
      * transaction is mined past the activation height.
      */
     @Test
@@ -94,7 +94,7 @@ public class FeeRatesSourceDefaultTest {
 
         FeeRatesSource effective = stored == null ? FeeRatesSource.getDefault() : stored;
         Assertions.assertEquals(FeeRatesSource.MEMPOOL_GUIDE, effective,
-                "so the wallet uses the default rather than a source that has not adopted the fork");
+                "so the wallet uses the default rather than a source that stopped at the activation height");
     }
 
     /**
@@ -113,31 +113,31 @@ public class FeeRatesSourceDefaultTest {
 
     /**
      * Broadcasting is the one that moves value. With a Tor proxy configured this path replaces the connected node
-     * rather than supplementing it, so a source that has not adopted the fork does not merely mislead: an opted-in
+     * rather than supplementing it, so a source that stopped at the activation height does not merely mislead: an opted-in
      * transaction is refused there, but a legacy one relays, which is the replay this wallet exists to prevent.
      */
     @Test
     public void testEveryBroadcastSourceHasAdoptedTheFork() {
         for(BroadcastSource source : BroadcastSource.values()) {
             Assertions.assertEquals(BroadcastSource.MEMPOOL_GUIDE, source,
-                    source + " would offer a transaction to nodes that have not adopted the fork");
+                    source + " would offer a transaction to nodes still on the old rules");
         }
     }
 
     /**
-     * An explorer that has not adopted the fork shows nothing for a transaction mined past activation. A
+     * An explorer that stopped at the activation height shows nothing for a transaction mined past activation. A
      * custom URL can still be set in the settings for anyone who wants one.
      */
     @Test
     public void testEveryOfferedExplorerHasAdoptedTheForkOrIsNone() {
         for(BlockExplorer explorer : BlockExplorer.values()) {
             Assertions.assertTrue(explorer == BlockExplorer.MEMPOOL_GUIDE || explorer == BlockExplorer.NONE,
-                    explorer + " points at an explorer that has not adopted the fork");
+                    explorer + " points at an explorer that stopped at the activation height");
         }
     }
 
     /**
-     * No public Electrum server has adopted the fork, and connecting to one would show the wallet blocks
+     * No public Electrum server kept up, and connecting to one would show the wallet blocks
      * and balances that diverge past the activation height. The option is withdrawn rather than filled with servers
      * that mislead; the entries stay in the enum only so upstream changes to that file keep merging.
      */
@@ -162,7 +162,7 @@ public class FeeRatesSourceDefaultTest {
         java.util.List<ServerType> offered = java.util.List.of(
                 com.sparrowwallet.sparrow.terminal.settings.ServerTypeDialog.getServerTypes());
         Assertions.assertFalse(offered.contains(ServerType.PUBLIC_ELECTRUM_SERVER),
-                "no public server has adopted the fork, so the terminal must not offer the type");
+                "no public server kept up, so the terminal must not offer the type");
         Assertions.assertTrue(offered.contains(ServerType.BITCOIN_CORE) && offered.contains(ServerType.ELECTRUM_SERVER),
                 "the two that can be configured must remain");
     }

--- a/src/test/java/com/sparrowwallet/sparrow/transaction/UnifiedSigHashItemsTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/transaction/UnifiedSigHashItemsTest.java
@@ -129,7 +129,7 @@ public class UnifiedSigHashItemsTest {
      * The wallet may produce ANYONECANPAY, because that is the type the user picked and refusing it would just be a
      * device that mysteriously will not sign. What it must never do is reach for it on its own account: a signature
      * that stands alone is the one legacy type that survives being lifted out and spent against nodes that
-     * have not adopted the fork, so the user has to have chosen it. This pins the one type the send screen puts forward by itself.
+     * stopped at the activation height, so the user has to have chosen it. This pins the one type the send screen puts forward by itself.
      */
     @Test
     public void testTheRecommendedTypeIsNeverAnyoneCanPay() {


### PR DESCRIPTION
Matches the repo wording to the website: the fork is a date the chain passed, not a side to join.