### PR TITLE
Replay needs the inputs to exist on the SHA256d chain, so say that

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The compiled-in height is cross checked against the connected node where it repo
 
 ## Replay protection
 
-A signature that does not opt in is valid under both rule sets, so it can be replayed against nodes still on the old rules. **Check the send screen before building anything.** The opt-in is selected by default:
+A signature that does not opt in is valid under both rule sets. Where the coins it spends also exist on the SHA256d chain, that makes the transaction replayable there. **Check the send screen before building anything.** The opt-in is selected by default:
 
 ![The send screen reporting a transaction as replay protected](docs/images/send-replay-protected.png)
 
@@ -37,9 +37,9 @@ Where a signer is the reason, tick it in the keystore tab of the wallet settings
 
 **In a multisig** one marked signer is enough. Mark two of a 2-of-3 and every transaction opts in; mark one and the opt-in depends on that signer taking part, which the wallet says rather than promising in advance.
 
-**The exception is Anyone Can Pay**, which commits only to its own input and the outputs, so that input can be lifted out and spent against nodes still on the old rules, even though the transaction cannot. The send screen names such signatures. Shrike never selects it by itself.
+**The exception is Anyone Can Pay**, which commits only to its own input and the outputs, so that input can be lifted out and spent on the SHA256d chain, even though the transaction cannot. The send screen names such signatures. Shrike never selects it by itself.
 
-Coins held across activation are only separated once spent with an opted-in signature, and a spend covers only the inputs it consumes, so sweep every pre-fork UTXO to yourself before transacting with nodes still on the old rules.
+Coins held across activation are only separated once spent with an opted-in signature, and a spend covers only the inputs it consumes, so sweep every pre-fork UTXO to yourself before transacting with anyone on the SHA256d chain.
 
 ## Building
 

--- a/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
+++ b/src/main/java/com/sparrowwallet/sparrow/UnifiedSigHashDecision.java
@@ -166,7 +166,7 @@ public enum UnifiedSigHashDecision {
      * What the signature does, in terms of the consequence rather than the hash type that carries it.
      *
      * The sighash control names the type already, and the byte is not what a person is deciding about:
-     * the choice is between a signature that cannot be replayed against nodes still on the old rules
+     * the choice is between a signature that cannot be replayed onto the SHA256d chain
      * fork and commits to the amounts it spends, and one that predates both guarantees.
      */
     public String getSummary() {

--- a/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/transaction/HeadersController.java
@@ -1099,10 +1099,10 @@ public class HeadersController extends TransactionFormController implements Init
         if(everySignature || signatures == 0) {
             //"the amount it spends" rather than "the amounts they spend": an Anyone Can Pay signature commits to its
             //own input's amount and no other, so the blanket claim was not true of one.
-            return "These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes still on the old rules, and each commits to the amount it spends.";
+            return "These signatures are not valid under the pre-fork rules, so they cannot be replayed onto the SHA256d chain, and each commits to the amount it spends.";
         }
 
-        String detail = "This transaction cannot be replayed against nodes still on the old rules: one signature that opts in is enough, and "
+        String detail = "This transaction cannot be replayed onto the SHA256d chain: one signature that opts in is enough, and "
                 + optedInSignatures + " of " + signatures + " do."
                 + System.lineSeparator() + System.lineSeparator()
                 + "The other " + (signatures - optedInSignatures) + " were made the way they always have been, so those signers were shown the amounts by this computer rather than committing to them.";
@@ -1112,8 +1112,8 @@ public class HeadersController extends TransactionFormController implements Init
         //protected either way, so this is the one case where the headline is true and still not the whole answer.
         if(liftable > 0) {
             detail += System.lineSeparator() + System.lineSeparator()
-                    + (liftable == 1 ? "One of those signs Anyone Can Pay, so it commits only to its own input and to the outputs. That input alone can be lifted into another transaction and spent against nodes still on the old rules, paying these same outputs."
-                                     : liftable + " of those sign Anyone Can Pay, so each commits only to its own input and to the outputs. Those inputs can be lifted into another transaction and spent against nodes still on the old rules, paying these same outputs.")
+                    + (liftable == 1 ? "One of those signs Anyone Can Pay, so it commits only to its own input and to the outputs. That input alone can be lifted into another transaction and spent on the SHA256d chain, paying these same outputs."
+                                     : liftable + " of those sign Anyone Can Pay, so each commits only to its own input and to the outputs. Those inputs can be lifted into another transaction and spent on the SHA256d chain, paying these same outputs.")
                     + " Have those signers opt in too, or sign the whole transaction with All, to close that.";
         }
 

--- a/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/wallet/SendController.java
@@ -1152,7 +1152,7 @@ public class SendController extends WalletFormController implements Initializabl
 
         StringBuilder detail = new StringBuilder();
         if(decision.isOptedIn()) {
-            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed against nodes still on the old rules, and each commits to the amount it spends.");
+            detail.append("These signatures are not valid under the pre-fork rules, so they cannot be replayed onto the SHA256d chain, and each commits to the amount it spends.");
             //Every caveat that applies, not only the one the headline came from: on an Electrum connection a
             //partially marked multisig has two, and the one the headline dropped is the actionable one
             for(String caveat : status.caveats()) {

--- a/src/main/resources/com/sparrowwallet/sparrow/wallet/keystore.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/wallet/keystore.fxml
@@ -114,7 +114,7 @@
             </Field>
             <Field fx:id="unifiedSigHashField" text="Replay protection:">
                 <CheckBox fx:id="unifiedSigHash" text="I confirm this device supports it" />
-                <HelpLabel helpText="Whether the signer behind this keystore produces the unified opt-in signature hash.\nA device reports its model but not its firmware, and a watch only keystore says nothing about what signs for it, so only you can say.\n\nLeave this off if you are unsure. A signature that does not opt in is valid under the pre-fork rules as well as the new ones, so it can be replayed against nodes still on the old rules.\n\nTurning it on for a device that does not support it does not fall back: the device signs nothing and reports a failure of its own." />
+                <HelpLabel helpText="Whether the signer behind this keystore produces the unified opt-in signature hash.\nA device reports its model but not its firmware, and a watch only keystore says nothing about what signs for it, so only you can say.\n\nLeave this off if you are unsure. A signature that does not opt in is valid under the pre-fork rules as well as the new ones, so where those coins also exist on the SHA256d chain it can be replayed there.\n\nTurning it on for a device that does not support it does not fall back: the device signs nothing and reports a failure of its own." />
             </Field>
         </Fieldset>
     </Form>

--- a/src/test/java/com/sparrowwallet/sparrow/net/FeeRatesSourceDefaultTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/net/FeeRatesSourceDefaultTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 /**
  * The default source has to be one that kept up.
  *
- * mempool.space stayed on the old rules, so past the activation height it holds neither this wallet's blocks
+ * mempool.space stayed on the SHA256d chain, so past the activation height it holds neither this wallet's blocks
  * nor its mempool, so it answers 404 for a block that exists and prices transactions against a mempool
  * this wallet never broadcasts into. Both were reached with the source left unset, which is the state every
  * new install starts in, so the default is the thing worth pinning.
@@ -120,7 +120,7 @@ public class FeeRatesSourceDefaultTest {
     public void testEveryBroadcastSourceHasAdoptedTheFork() {
         for(BroadcastSource source : BroadcastSource.values()) {
             Assertions.assertEquals(BroadcastSource.MEMPOOL_GUIDE, source,
-                    source + " would offer a transaction to nodes still on the old rules");
+                    source + " would offer a transaction to the SHA256d chain");
         }
     }
 


### PR DESCRIPTION
Not opting in does not by itself make a transaction replayable: the inputs also have to exist on the SHA256d chain. Names that chain rather than calling it the old rules.